### PR TITLE
[JENKINS-72482] Replace the deleted Jackson 2 API constants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,12 +193,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.15.2</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/gitee/jenkins/gitee/JacksonConfig.java
+++ b/src/main/java/com/gitee/jenkins/gitee/JacksonConfig.java
@@ -19,7 +19,7 @@ import javax.ws.rs.ext.Provider;
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public ObjectMapper getContext(Class<?> type) {
         return new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+                .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }

--- a/src/main/java/com/gitee/jenkins/util/JsonUtil.java
+++ b/src/main/java/com/gitee/jenkins/util/JsonUtil.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 public final class JsonUtil {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(SerializationFeature.INDENT_OUTPUT, true)


### PR DESCRIPTION
## [JENKINS-72482] Replace the deleted Jackson 2 API constants

The Jackson API plugin 2.16.1 has removed two constants that were deprecated long ago. The removal of those constants will break compilation of the gitee plugin and are expected to break runtime of the gitee plugin as well.

This pull request upgrades from Jackson 2 API 2.15.2 to Jackson 2 API 2.16.1 so that the API deletion of the constants is visible at compile time.  A Jenkins controller with the Jackson 2 API plugin 2.16.1-373.ve709c6871598 installed may already make this change visible to a gitee plugin at run time without any change to the plugin source code.

[Jackson databind PR 4162](https://github.com/FasterXML/jackson-databind/pull/4162) removed the constants from the Jackson 2 API after a long period of deprecation.  The changes were released in Jackson databind 2.16.0 and first included in the matching Jenkins API plugin 2.16.1-373.ve709c6871598.

Similar change was needed in the GitLab plugin and is implemented in [GitLab plugin PR 1606](https://github.com/jenkinsci/gitlab-plugin/pull/1606).  That change is released as [GitLab plugin 1.8.0](https://github.com/jenkinsci/gitlab-plugin/releases/tag/gitlab-plugin-1.8.0).

The gitee plugin and the GitLab plugin appear to be the only two Jenkins plugins using this constant, per a GitHub search.  [JENKINS-72482](https://issues.jenkins.io/browse/JENKINS-72482) provides more details for the gitee plugin.  [JENKINS-72476](https://issues.jenkins.io/browse/JENKINS-72476) provides more details for the GitLab plugin.

### Testing done

Confirmed that compilation fails after upgrade to Jackson 2 API 2.16.1 and that compilation passes and tests run successfully after the constants are renamed.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
