### PR TITLE
Use RESTEasy client 3.0.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>3.0.16.Final</version>
+      <version>3.0.23.Final</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
The RESTEasy client 3.0.23 is the most recent client library version
that does not cause compilation to fail due to the initDefaultEngine()
method that was removed in RESTEasy client 3.0.24.

It was released in May 2017.

https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-client/3.0.23.Final
shows the RESTEasy client 3.0.23 release with 2 known vulnerabilities:

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25633
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1695

https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-client/3.0.16.Final
shows the RESTEasy client 3.0.16 release with 5 known vulnerabilities:

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25633
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1695
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6348
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6347
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6345
