### PR TITLE
Require Jenkins 2.414.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <!-- Needs to match the jackson version from plugin BOM -->
-      <version>2.15.1</version>
+      <version>2.17.0</version>
     </dependency>
 
     <!-- util dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -60,8 +60,8 @@
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2928.ved44ea_84e034</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.414.3 or newer

Require Jenkins 2.414.3 or newer

Must require that Jenkins 2.414.3 or newer in order to keep the jackson-jaxrs-json-provider version in sync with the most recent release of the jackson2 api plugin.

Also includes pull request:

* #36

### Testing done

Confirmed that the code compiles.  Rely on ci.jenkins.io for further testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
