### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/com/gitee/jenkins/environment/GiteeEnvironmentContributor.java
+++ b/src/main/java/com/gitee/jenkins/environment/GiteeEnvironmentContributor.java
@@ -1,6 +1,7 @@
 package com.gitee.jenkins.environment;
 
 import com.gitee.jenkins.cause.GiteeWebHookCause;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixRun;
@@ -9,7 +10,6 @@ import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -18,7 +18,7 @@ import java.io.IOException;
 @Extension
 public class GiteeEnvironmentContributor extends EnvironmentContributor {
     @Override
-    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+    public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
         GiteeWebHookCause cause = null;
         if (r instanceof MatrixRun) {
             MatrixBuild parent = ((MatrixRun)r).getParentBuild();

--- a/src/main/java/com/gitee/jenkins/gitee/api/GiteeClientBuilder.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/GiteeClientBuilder.java
@@ -1,12 +1,11 @@
 package com.gitee.jenkins.gitee.api;
 
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,16 +40,16 @@ public abstract class GiteeClientBuilder implements Comparable<GiteeClientBuilde
         this.ordinal = ordinal;
     }
 
-    @Nonnull
+    @NonNull
     public final String id() {
         return id;
     }
 
-    @Nonnull
+    @NonNull
     public abstract GiteeClient buildClient(String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
 
     @Override
-    public final int compareTo(@Nonnull GiteeClientBuilder other) {
+    public final int compareTo(@NonNull GiteeClientBuilder other) {
         int o = ordinal - other.ordinal;
         return o != 0 ? o : id().compareTo(other.id());
     }

--- a/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClientBuilder.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClientBuilder.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.ProxyConfiguration;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -29,8 +31,6 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.client.ClientRequestContext;
@@ -75,7 +75,7 @@ public class ResteasyGiteeClientBuilder extends GiteeClientBuilder {
         this.pullRequestIdProvider = pullRequestIdProvider;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public final GiteeClient buildClient(String url, String apiToken, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
         return buildClient(


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The  mailing list discussion at https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ describes the affected annotations and why they should be replaced with annotations that are actively maintained.

An OpenRewrite recipe https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs provides this upgrade, though it upgraded the Priority annotation and that annotation needs to remain because it is used by RestEasy.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
