### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -63,7 +63,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4136.vca_c3202a_7fd1</version>
+        <version>4545.v56392b_7ca_7b_a_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -17,7 +17,7 @@
   <licenses>
     <license>
       <name>GPL v2.0 License</name>
-      <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</url>
+      <url>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</url>
     </license>
   </licenses>
 
@@ -52,8 +52,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -63,7 +63,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -107,14 +107,15 @@
 
     <!-- REST client dependencies -->
     <dependency>
-      <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-      <version>1.0.1.Final</version>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>3.0.23.Final</version>
+      <version>6.2.11.Final</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -129,8 +130,8 @@
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <!-- Needs to match the jackson version from plugin BOM -->
       <version>2.17.0</version>
     </dependency>

--- a/src/main/java/com/gitee/jenkins/cause/CauseData.java
+++ b/src/main/java/com/gitee/jenkins/cause/CauseData.java
@@ -1,6 +1,7 @@
 package com.gitee.jenkins.cause;
 
 import com.gitee.jenkins.gitee.api.model.PullRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.markup.EscapedMarkupFormatter;
 import jenkins.model.Jenkins;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
@@ -124,7 +125,7 @@ public final class CauseData {
     }
 
     public Map<String, String> getBuildVariables() {
-        MapWrapper<String, String> variables = new MapWrapper<>(new HashMap<String, String>());
+        MapWrapper<String, String> variables = new MapWrapper<>(new HashMap<>());
         variables.put("giteeBranch", branch);
         variables.put("giteeSourceBranch", sourceBranch);
         variables.put("giteeActionType", actionType.name());
@@ -518,7 +519,7 @@ public final class CauseData {
             @Override
             String getShortDescription(CauseData data) {
                 String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch()) ? "" : data.getSourceNamespace() + "/";
-                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
+                if (Jenkins.get().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
                     return Messages.GiteeWebHookCause_ShortDescription_PullRequestHook_plain(String.valueOf(data.getPullRequestIid()),
                                                                                                forkNamespace + data.getSourceBranch(),
                                                                                                data.getTargetBranch());
@@ -534,7 +535,7 @@ public final class CauseData {
             String getShortDescription(CauseData data) {
                 String triggeredBy = data.getTriggeredByUser();
                 String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch()) ? "" : data.getSourceNamespace() + "/";
-                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
+                if (Jenkins.get().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
                     return Messages.GiteeWebHookCause_ShortDescription_NoteHook_plain(triggeredBy,
                         String.valueOf(data.getPullRequestIid()),
                         forkNamespace + data.getSourceBranch(),
@@ -589,6 +590,7 @@ public final class CauseData {
             return map.put(key, value);
         }
 
+        @NonNull
         @Override
         public Set<Entry<K, V>> entrySet() {
             return map.entrySet();

--- a/src/main/java/com/gitee/jenkins/connection/GiteeApiToken.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeApiToken.java
@@ -3,6 +3,7 @@ package com.gitee.jenkins.connection;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.util.Secret;
 
@@ -15,8 +16,10 @@ public interface GiteeApiToken extends StandardCredentials {
     Secret getApiToken();
 
     class NameProvider extends CredentialsNameProvider<GiteeApiToken> {
+
+        @NonNull
         @Override
-        public String getName(GiteeApiToken c) {
+        public String getName(@NonNull GiteeApiToken c) {
             String description = Util.fixEmptyAndTrim(c.getDescription());
             return Messages.GiteeApiToken_name() + (description != null ? " (" + description + ")" : "");
         }

--- a/src/main/java/com/gitee/jenkins/connection/GiteeApiTokenImpl.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeApiTokenImpl.java
@@ -2,6 +2,7 @@ package com.gitee.jenkins.connection;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -26,6 +27,8 @@ public final class GiteeApiTokenImpl extends BaseStandardCredentials implements 
 
     @Extension
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.GiteeApiToken_name();

--- a/src/main/java/com/gitee/jenkins/connection/GiteeConnectionConfig.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeConnectionConfig.java
@@ -21,10 +21,10 @@ import net.sf.json.JSONObject;
 import org.eclipse.jgit.util.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,7 +49,7 @@ public class GiteeConnectionConfig extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         connections = req.bindJSONToList(GiteeConnection.class, json.get("connections"));
 //        useAuthenticatedEndpoint = json.getBoolean("useAuthenticatedEndpoint");
         refreshConnectionMap();
@@ -152,11 +152,11 @@ public class GiteeConnectionConfig extends GlobalConfiguration {
     }
 
     public ListBoxModel doFillApiTokenIdItems(@QueryParameter String name, @QueryParameter String url) {
-        if (Jenkins.getInstance().hasPermission(Item.CONFIGURE)) {
+        if (Jenkins.get().hasPermission(Item.CONFIGURE)) {
             AbstractIdCredentialsListBoxModel<StandardListBoxModel, StandardCredentials> options = new StandardListBoxModel()
                 .includeEmptyValue()
-                .includeMatchingAs(ACL.SYSTEM,
-                                   Jenkins.getActiveInstance(),
+                .includeMatchingAs(ACL.SYSTEM2,
+                                   Jenkins.get(),
                                    StandardCredentials.class,
                                    URIRequirementBuilder.fromUri(url).build(),
                                    new GiteeCredentialMatcher());

--- a/src/main/java/com/gitee/jenkins/connection/GiteeConnectionProperty.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeConnectionProperty.java
@@ -2,6 +2,7 @@ package com.gitee.jenkins.connection;
 
 
 import com.gitee.jenkins.gitee.api.GiteeClient;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.JobProperty;
@@ -13,7 +14,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * @author Robin Müller
@@ -33,7 +34,7 @@ public class GiteeConnectionProperty extends JobProperty<Job<?, ?>> {
 
     public GiteeClient getClient() {
         if (StringUtils.isNotEmpty(giteeConnection)) {
-            GiteeConnectionConfig connectionConfig = (GiteeConnectionConfig) Jenkins.getInstance().getDescriptor(GiteeConnectionConfig.class);
+            GiteeConnectionConfig connectionConfig = (GiteeConnectionConfig) Jenkins.get().getDescriptor(GiteeConnectionConfig.class);
             return connectionConfig != null ? connectionConfig.getClient(giteeConnection) : null;
         }
         return null;
@@ -60,6 +61,7 @@ public class GiteeConnectionProperty extends JobProperty<Job<?, ?>> {
     @Symbol("giteeConnection")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Gitee connection";
@@ -71,13 +73,13 @@ public class GiteeConnectionProperty extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(GiteeConnectionProperty.class, formData);
         }
 
         public ListBoxModel doFillGiteeConnectionItems() {
             ListBoxModel options = new ListBoxModel();
-            GiteeConnectionConfig descriptor = (GiteeConnectionConfig) Jenkins.getInstance().getDescriptor(GiteeConnectionConfig.class);
+            GiteeConnectionConfig descriptor = (GiteeConnectionConfig) Jenkins.get().getDescriptor(GiteeConnectionConfig.class);
             for (GiteeConnection connection : descriptor.getConnections()) {
                 options.add(connection.getName(), connection.getName());
             }

--- a/src/main/java/com/gitee/jenkins/environment/GiteeEnvironmentContributor.java
+++ b/src/main/java/com/gitee/jenkins/environment/GiteeEnvironmentContributor.java
@@ -20,10 +20,10 @@ public class GiteeEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
         GiteeWebHookCause cause = null;
-        if (r instanceof MatrixRun) {
-            MatrixBuild parent = ((MatrixRun)r).getParentBuild();
+        if (r instanceof MatrixRun run) {
+            MatrixBuild parent = run.getParentBuild();
             if (parent != null) {
-                cause = (GiteeWebHookCause) parent.getCause(GiteeWebHookCause.class);
+                cause = parent.getCause(GiteeWebHookCause.class);
             }
         } else {
             cause = (GiteeWebHookCause) r.getCause(GiteeWebHookCause.class);

--- a/src/main/java/com/gitee/jenkins/gitee/JacksonConfig.java
+++ b/src/main/java/com/gitee/jenkins/gitee/JacksonConfig.java
@@ -2,13 +2,13 @@ package com.gitee.jenkins.gitee;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * @author Robin Müller
@@ -19,7 +19,7 @@ import javax.ws.rs.ext.Provider;
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public ObjectMapper getContext(Class<?> type) {
         return new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }

--- a/src/main/java/com/gitee/jenkins/gitee/api/GiteeClientBuilder.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/GiteeClientBuilder.java
@@ -27,7 +27,7 @@ public abstract class GiteeClientBuilder implements Comparable<GiteeClientBuilde
     }
 
     public static List<GiteeClientBuilder> getAllGiteeClientBuilders() {
-        List<GiteeClientBuilder> builders = new ArrayList<>(Jenkins.getInstance().getExtensionList(GiteeClientBuilder.class));
+        List<GiteeClientBuilder> builders = new ArrayList<>(Jenkins.get().getExtensionList(GiteeClientBuilder.class));
         sort(builders);
         return builders;
     }

--- a/src/main/java/com/gitee/jenkins/gitee/api/impl/GiteeV5ApiProxy.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/impl/GiteeV5ApiProxy.java
@@ -1,8 +1,8 @@
 package com.gitee.jenkins.gitee.api.impl;
 
 import com.gitee.jenkins.gitee.api.model.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 
 
 /**

--- a/src/main/java/com/gitee/jenkins/gitee/api/impl/GiteeV5ClientBuilder.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/impl/GiteeV5ClientBuilder.java
@@ -12,12 +12,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public final class GiteeV5ClientBuilder extends ResteasyGiteeClientBuilder {
     private static final int ORDINAL = 3;
-    private static final Function<PullRequest, Integer> MERGE_REQUEST_ID_PROVIDER = new Function<PullRequest, Integer>() {
-        @Override
-        public Integer apply(PullRequest pullRequest) {
-            return pullRequest.getIid();
-        }
-    };
+    private static final Function<PullRequest, Integer> MERGE_REQUEST_ID_PROVIDER = PullRequest::getIid;
 
     public GiteeV5ClientBuilder() {
         super(GiteeV5ApiProxy.ID, ORDINAL, GiteeV5ApiProxy.class, MERGE_REQUEST_ID_PROVIDER);

--- a/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClient.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClient.java
@@ -19,7 +19,7 @@ final class ResteasyGiteeClient implements GiteeClient {
     }
 
     @Override
-    public final String getHostUrl() {
+    public String getHostUrl() {
         return hostUrl;
     }
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteHook.java
@@ -57,6 +57,7 @@ public class NoteHook extends WebHook {
         this.pullRequest = pullRequest;
     }
 
+    @Override
     public String getWebHookDescription() {
         // 兼容commit评论
         if (pullRequest == null) {

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestHook.java
@@ -88,6 +88,7 @@ public class PullRequestHook extends WebHook {
         this.labels = labels;
     }
 
+    @Override
     public String getWebHookDescription() {
         return getHookName() + " iid = " + pullRequest.getNumber() + " merge commit sha = " + pullRequest.getMergeCommitSha();
     }

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestObjectAttributes.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestObjectAttributes.java
@@ -1,7 +1,6 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PushHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PushHook.java
@@ -127,6 +127,7 @@ public class PushHook extends WebHook {
         this.totalCommitsCount = totalCommitsCount;
     }
 
+    @Override
     public String getWebHookDescription() {
         return getHookName() + " ref = " + ref + " commit sha = " + after;
     }

--- a/src/main/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisher.java
+++ b/src/main/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisher.java
@@ -3,6 +3,7 @@ package com.gitee.jenkins.publisher;
 
 import com.gitee.jenkins.gitee.api.GiteeClient;
 import com.gitee.jenkins.gitee.api.model.PullRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Result;
@@ -13,8 +14,8 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -27,6 +28,7 @@ public class GiteeAcceptPullRequestPublisher extends PullRequestNotifier {
     @DataBoundConstructor
     public GiteeAcceptPullRequestPublisher() { }
 
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
@@ -39,6 +41,7 @@ public class GiteeAcceptPullRequestPublisher extends PullRequestNotifier {
             return true;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.GiteeAcceptPullRequestPublisher_DisplayName();

--- a/src/main/java/com/gitee/jenkins/publisher/GiteeMessagePublisher.java
+++ b/src/main/java/com/gitee/jenkins/publisher/GiteeMessagePublisher.java
@@ -3,21 +3,18 @@ package com.gitee.jenkins.publisher;
 
 import com.gitee.jenkins.gitee.api.GiteeClient;
 import com.gitee.jenkins.gitee.api.model.PullRequest;
-import com.gitee.jenkins.trigger.GiteePushTrigger;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
-import hudson.triggers.Trigger;
 import jenkins.model.Jenkins;
-import jenkins.model.ParameterizedJobMixIn;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,12 +58,11 @@ public class GiteeMessagePublisher extends PullRequestNotifier {
 
     public static GiteeMessagePublisher getFromJob(Job<?, ?> job) {
         GiteeMessagePublisher publisher = null;
-        if (job instanceof AbstractProject) {
-            AbstractProject p = (AbstractProject) job;
+        if (job instanceof AbstractProject p) {
             Map<Descriptor<Publisher>, Publisher> map = p.getPublishersList().toMap();
             for (Publisher n : map.values()) {
-                if (n instanceof GiteeMessagePublisher) {
-                    publisher = (GiteeMessagePublisher) n;
+                if (n instanceof GiteeMessagePublisher giteePublisher) {
+                    publisher = giteePublisher;
                 }
             }
         }
@@ -162,6 +158,7 @@ public class GiteeMessagePublisher extends PullRequestNotifier {
             return true;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.GiteeMessagePublisher_DisplayName();
@@ -238,9 +235,9 @@ public class GiteeMessagePublisher extends PullRequestNotifier {
             message = replaceMacros(build, listener, this.getFailureNoteText());
         } else {
             String icon = getResultIcon(build.getResult());
-            String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
+            String buildUrl = Jenkins.get().getRootUrl() + build.getUrl();
             message = MessageFormat.format("{0} Jenkins Build {1}\n\nResults available at: [Jenkins [{2} # {3}]]({4})",
-                                           icon, build.getResult().toString(), build.getParent().getDisplayName(), build.getNumber(), buildUrl);
+                                           icon, build.getResult(), build.getParent().getDisplayName(), build.getNumber(), buildUrl);
         }
         return message;
     }

--- a/src/main/java/com/gitee/jenkins/publisher/PullRequestNotifier.java
+++ b/src/main/java/com/gitee/jenkins/publisher/PullRequestNotifier.java
@@ -22,6 +22,8 @@ import static com.gitee.jenkins.connection.GiteeConnectionProperty.getClient;
  * @author Robin Müller
  */
 public abstract class PullRequestNotifier extends Notifier implements MatrixAggregatable {
+
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }

--- a/src/main/java/com/gitee/jenkins/trigger/branch/AntPathMatcherSet.java
+++ b/src/main/java/com/gitee/jenkins/trigger/branch/AntPathMatcherSet.java
@@ -10,9 +10,9 @@ import java.util.HashSet;
  */
 class AntPathMatcherSet extends HashSet<String> {
 
-    private transient final AntPathMatcher matcher = new AntPathMatcher();
+    private final transient AntPathMatcher matcher = new AntPathMatcher();
 
-    public AntPathMatcherSet(Collection<? extends String> c) {
+    public AntPathMatcherSet(Collection<String> c) {
         super(c);
     }
 

--- a/src/main/java/com/gitee/jenkins/trigger/filter/BranchFilterFactory.java
+++ b/src/main/java/com/gitee/jenkins/trigger/filter/BranchFilterFactory.java
@@ -8,17 +8,15 @@ public final class BranchFilterFactory {
     private BranchFilterFactory() { }
 
     public static BranchFilter newBranchFilter(BranchFilterConfig config) {
-		
+
 		if(config == null)
 			return new AllBranchesFilter();
-		
-        switch (config.getType()) {
-            case NameBasedFilter:
-                return new NameBasedFilter(config.getIncludeBranchesSpec(), config.getExcludeBranchesSpec());
-            case RegexBasedFilter:
-                return new RegexBasedFilter(config.getTargetBranchRegex());
-            default:
-                return new AllBranchesFilter();
-        }
+
+        return switch (config.getType()) {
+            case NameBasedFilter ->
+                new NameBasedFilter(config.getIncludeBranchesSpec(), config.getExcludeBranchesSpec());
+            case RegexBasedFilter -> new RegexBasedFilter(config.getTargetBranchRegex());
+            default -> new AllBranchesFilter();
+        };
     }
 }

--- a/src/main/java/com/gitee/jenkins/trigger/filter/BuildInstructionFilterType.java
+++ b/src/main/java/com/gitee/jenkins/trigger/filter/BuildInstructionFilterType.java
@@ -20,7 +20,7 @@ public enum BuildInstructionFilterType implements BuildInstructionFilter {
     CI_SKIP("[ci-skip]") {
         @Override
         public boolean isBuildAllow(String body) {
-            return body == null ? true : !body.contains(getBody());
+            return body == null || !body.contains(getBody());
         }
     },
     /**
@@ -29,11 +29,11 @@ public enum BuildInstructionFilterType implements BuildInstructionFilter {
     CI_BUILD("[ci-build]") {
         @Override
         public boolean isBuildAllow(String body) {
-            return body == null ? false : body.contains(getBody());
+            return body != null && body.contains(getBody());
         }
     };
 
-    private String body;
+    private final String body;
 
     BuildInstructionFilterType(String body) {
         this.body = body;

--- a/src/main/java/com/gitee/jenkins/trigger/filter/NameBasedFilter.java
+++ b/src/main/java/com/gitee/jenkins/trigger/filter/NameBasedFilter.java
@@ -51,7 +51,7 @@ class NameBasedFilter implements BranchFilter {
 
     private List<String> convert(String commaSeparatedString) {
         if (commaSeparatedString == null)
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
 
         ArrayList<String> result = new ArrayList<>();
         for (String s : Splitter.on(',').omitEmptyStrings().trimResults().split(commaSeparatedString)) {

--- a/src/main/java/com/gitee/jenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -18,7 +18,7 @@ import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -100,8 +100,7 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
 
     protected void scheduleBuild(Job<?, ?> job, Action[] actions) {
         int projectBuildDelay = 0;
-        if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
-            ParameterizedJobMixIn.ParameterizedJob abstractProject = (ParameterizedJobMixIn.ParameterizedJob) job;
+        if (job instanceof ParameterizedJobMixIn.ParameterizedJob abstractProject) {
             if (abstractProject.getQuietPeriod() > projectBuildDelay) {
                 projectBuildDelay = abstractProject.getQuietPeriod();
             }
@@ -122,8 +121,8 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
     private GitSCM getGitSCM(SCMTriggerItem item) {
         if (item != null) {
             for (SCM scm : item.getSCMs()) {
-                if (scm instanceof GitSCM) {
-                    return (GitSCM) scm;
+                if (scm instanceof GitSCM gitSCM) {
+                    return gitSCM;
                 }
             }
         }
@@ -132,11 +131,11 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
 
     protected void doStop(Run<?, ?> build) throws IOException, ServletException {
         if (build.isBuilding()) {
-            if (build instanceof AbstractBuild) {
-                ((AbstractBuild) build).doStop();
+            if (build instanceof AbstractBuild abstractBuild) {
+                abstractBuild.doStop();
                 LOGGER.log(Level.WARNING, "Abort incomplete build");
-            } else if (build instanceof WorkflowRun) {
-                ((WorkflowRun) build).doStop();
+            } else if (build instanceof WorkflowRun workflowRun) {
+                workflowRun.doStop();
                 LOGGER.log(Level.WARNING, "Abort incomplete build");
             } else {
                 LOGGER.log(Level.WARNING, "Unable to abort incomplete build, build type not found: " + build.getClass().getName());

--- a/src/main/java/com/gitee/jenkins/trigger/handler/PendingBuildsHandler.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/PendingBuildsHandler.java
@@ -16,7 +16,7 @@ public class PendingBuildsHandler {
     private static final Logger LOGGER = Logger.getLogger(PendingBuildsHandler.class.getName());
 
     public void cancelPendingBuilds(Job<?, ?> job, Integer projectId, String branch) {
-        Queue queue = Jenkins.getInstance().getQueue();
+        Queue queue = Jenkins.get().getQueue();
         for (Queue.Item item : queue.getItems()) {
             if (!job.getName().equals(item.task.getName())) {
                 continue;
@@ -37,8 +37,8 @@ public class PendingBuildsHandler {
 
     private GiteeWebHookCause getGiteeWebHookCauseData(Queue.Item item) {
         for (Cause cause : item.getCauses()) {
-            if (cause instanceof GiteeWebHookCause) {
-                return (GiteeWebHookCause) cause;
+            if (cause instanceof GiteeWebHookCause webHookCause) {
+                return webHookCause;
             }
         }
         return null;

--- a/src/main/java/com/gitee/jenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -17,7 +17,7 @@ import hudson.plugins.git.RevisionParameterAction;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -110,8 +110,8 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
             CauseAction causeAction = build.getAction(CauseAction.class);
             GiteeWebHookCause giteeWebHookCause = null;
             for (Cause cause : causeAction.getCauses()) {
-                if (cause instanceof GiteeWebHookCause) {
-                    giteeWebHookCause = (GiteeWebHookCause) cause;
+                if (cause instanceof GiteeWebHookCause webHookCause) {
+                    giteeWebHookCause = webHookCause;
                     break;
                 }
             }

--- a/src/main/java/com/gitee/jenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
@@ -3,7 +3,6 @@ package com.gitee.jenkins.trigger.handler.pipeline;
 
 import com.gitee.jenkins.cause.CauseData;
 import com.gitee.jenkins.connection.GiteeConnectionProperty;
-import com.gitee.jenkins.gitee.api.GiteeClient;
 import com.gitee.jenkins.gitee.hook.model.PipelineEventObjectAttributes;
 import com.gitee.jenkins.gitee.hook.model.PipelineHook;
 import com.gitee.jenkins.trigger.exception.NoRevisionToBuildException;
@@ -19,7 +18,7 @@ import hudson.model.Run;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -109,7 +108,7 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                 .withSourceRepoName(hook.getRepository()==null||hook.getRepository().getName()==null?"":hook.getRepository().getName())
                 .withSourceNamespace(hook.getProject()==null||hook.getProject().getNamespace()==null?"":hook.getProject().getNamespace())
                 .withSourceRepoSshUrl(hook.getRepository()==null||hook.getRepository().getGitSshUrl()==null?"":hook.getRepository().getGitSshUrl())
-                .withSourceRepoHttpUrl(hook.getRepository()==null||hook.getRepository()==null?"":hook.getRepository().getGitHttpUrl())
+                .withSourceRepoHttpUrl(hook.getRepository()==null||hook.getRepository().getGitHttpUrl()==null?"":hook.getRepository().getGitHttpUrl())
                 .withPullRequestTitle("")
                 .withTargetProjectId(hook.getProjectId())
                 .withTargetBranch(getTargetBranch(hook)==null?"":getTargetBranch(hook))
@@ -122,7 +121,7 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                 .withRef(hook.getObjectAttributes().getRef()==null?"":hook.getObjectAttributes().getRef())
                 .withSha(hook.getObjectAttributes().getSha()==null?"":hook.getObjectAttributes().getSha())
                 .withBeforeSha(hook.getObjectAttributes().getBeforeSha()==null?"":hook.getObjectAttributes().getBeforeSha())
-                .withStatus(hook.getObjectAttributes().getStatus()==null?"":hook.getObjectAttributes().getStatus().toString())
+                .withStatus(hook.getObjectAttributes().getStatus()==null?"":hook.getObjectAttributes().getStatus())
                 .withStages(hook.getObjectAttributes().getStages()==null?"":hook.getObjectAttributes().getStages().toString())
                 .withCreatedAt(hook.getObjectAttributes().getCreatedAt()==null?"":hook.getObjectAttributes().getCreatedAt().toString())
                 .withFinishedAt(hook.getObjectAttributes().getFinishedAt()==null?"":hook.getObjectAttributes().getFinishedAt().toString())

--- a/src/main/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImpl.java
@@ -6,7 +6,6 @@ import com.gitee.jenkins.gitee.api.GiteeClient;
 import com.gitee.jenkins.gitee.api.model.PullRequest;
 import com.gitee.jenkins.gitee.hook.model.*;
 import com.gitee.jenkins.gitee.hook.model.Action;
-import com.gitee.jenkins.gitee.hook.model.PullRequestHook;
 import com.gitee.jenkins.publisher.GiteeMessagePublisher;
 import com.gitee.jenkins.trigger.exception.NoRevisionToBuildException;
 import com.gitee.jenkins.trigger.filter.BranchFilter;
@@ -20,7 +19,7 @@ import hudson.plugins.git.RevisionParameterAction;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.ArrayList;
@@ -108,7 +107,7 @@ class PullRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pu
                 LOGGER.log(Level.INFO, "request is not allow, hook state=" + hook.getState() + ", action = " + hook.getAction() + ", action desc = " + hook.getActionDesc());
             }
         } catch (Exception e) {
-            LOGGER.log(Level.INFO, "request is not allow, hook ----- #" + hook.toString());
+            LOGGER.log(Level.INFO, "request is not allow, hook ----- #" + hook);
             throw e;
         }
 

--- a/src/main/java/com/gitee/jenkins/util/ACLUtil.java
+++ b/src/main/java/com/gitee/jenkins/util/ACLUtil.java
@@ -1,7 +1,9 @@
 package com.gitee.jenkins.util;
 
 import hudson.security.ACL;
-import org.acegisecurity.Authentication;
+import hudson.security.ACLContext;
+import org.springframework.security.core.Authentication;
+
 
 /**
  * @author Robin Müller
@@ -9,13 +11,11 @@ import org.acegisecurity.Authentication;
 public class ACLUtil {
 
     public static <T> T impersonate(Authentication auth, final Function<T> function) {
-        final ObjectHolder<T> holder = new ObjectHolder<T>();
-        ACL.impersonate(auth, new Runnable() {
-            public void run() {
-                holder.setValue(function.invoke());
-            }
-        });
-        return holder.getValue();
+        try (ACLContext ignored = ACL.as2(auth)) {
+            final ObjectHolder<T> holder = new ObjectHolder<>();
+            holder.setValue(function.invoke());
+            return holder.getValue();
+        }
     }
 
     public interface Function<T> {

--- a/src/main/java/com/gitee/jenkins/util/JsonUtil.java
+++ b/src/main/java/com/gitee/jenkins/util/JsonUtil.java
@@ -3,7 +3,7 @@ package com.gitee.jenkins.util;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
@@ -20,7 +20,7 @@ import java.util.Locale;
 public final class JsonUtil {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(SerializationFeature.INDENT_OUTPUT, true)
@@ -50,20 +50,20 @@ public final class JsonUtil {
         };
 
         private DateModule() {
-            addDeserializer(Date.class, new com.fasterxml.jackson.databind.JsonDeserializer<Date>() {
+            addDeserializer(Date.class, new com.fasterxml.jackson.databind.JsonDeserializer<>() {
                 @Override
                 public Date deserialize(com.fasterxml.jackson.core.JsonParser p, DeserializationContext ctxt) throws IOException {
                     for (String format : DATE_FORMATS) {
                         try {
                             return new SimpleDateFormat(format, Locale.US)
-                                    .parse(p.getValueAsString());
+                                .parse(p.getValueAsString());
                         } catch (ParseException e) {
                             // nothing to do
                         }
                     }
                     throw new IOException("Unparseable date: \""
-                            + p.getValueAsString() + "\". Supported formats: "
-                            + Arrays.toString(DATE_FORMATS));
+                        + p.getValueAsString() + "\". Supported formats: "
+                        + Arrays.toString(DATE_FORMATS));
                 }
             });
         }

--- a/src/main/java/com/gitee/jenkins/util/ProjectIdUtil.java
+++ b/src/main/java/com/gitee/jenkins/util/ProjectIdUtil.java
@@ -22,14 +22,14 @@ public final class ProjectIdUtil {
             String baseUri = client.getHostUrl();
             String projectId;
             if (baseUri != null && remoteUrl.startsWith(baseUri)) {
-                projectId = new URIish(remoteUrl.substring(baseUri.length(), remoteUrl.length())).getPath();
+                projectId = new URIish(remoteUrl.substring(baseUri.length())).getPath();
             } else {
                 projectId = new URIish(remoteUrl).getPath();
             }
             if (projectId.startsWith(":")) {
                 projectId = projectId.substring(1);
             }
-            
+
             Matcher matcher = PROJECT_ID_PATTERN.matcher(projectId);
             if (matcher.matches()) {
                 return matcher.group("projectId");

--- a/src/main/java/com/gitee/jenkins/webhook/GiteeOldWebHook.java
+++ b/src/main/java/com/gitee/jenkins/webhook/GiteeOldWebHook.java
@@ -3,13 +3,13 @@ package com.gitee.jenkins.webhook;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,7 +26,7 @@ public class GiteeOldWebHook implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(GiteeOldWebHook.class.getName());
 
-    private transient final ActionResolver actionResolver = new ActionResolver();
+    private final transient ActionResolver actionResolver = new ActionResolver();
 
     public String getIconFileName() {
         return null;
@@ -40,7 +40,7 @@ public class GiteeOldWebHook implements UnprotectedRootAction {
         return WEBHOOK_URL;
     }
 
-    public void getDynamic(final String projectName, final StaplerRequest request, StaplerResponse response) {
+    public void getDynamic(final String projectName, final StaplerRequest2 request, StaplerResponse2 response) {
         LOGGER.log(Level.INFO, "WebHook called with url: {0}", request.getRequestURIWithQueryString());
         actionResolver.resolve(projectName, request).execute(response);
     }

--- a/src/main/java/com/gitee/jenkins/webhook/GiteeWebHook.java
+++ b/src/main/java/com/gitee/jenkins/webhook/GiteeWebHook.java
@@ -3,13 +3,13 @@ package com.gitee.jenkins.webhook;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,7 +26,7 @@ public class GiteeWebHook implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(GiteeWebHook.class.getName());
 
-    private transient final ActionResolver actionResolver = new ActionResolver();
+    private final transient ActionResolver actionResolver = new ActionResolver();
 
     public String getIconFileName() {
         return null;
@@ -40,7 +40,7 @@ public class GiteeWebHook implements UnprotectedRootAction {
         return WEBHOOK_URL;
     }
 
-    public void getDynamic(final String projectName, final StaplerRequest request, StaplerResponse response) {
+    public void getDynamic(final String projectName, final StaplerRequest2 request, StaplerResponse2 response) {
         LOGGER.log(Level.INFO, "WebHook called with url: {0}", request.getRequestURIWithQueryString());
         actionResolver.resolve(projectName, request).execute(response);
     }

--- a/src/main/java/com/gitee/jenkins/webhook/WebHookAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/WebHookAction.java
@@ -1,10 +1,10 @@
 package com.gitee.jenkins.webhook;
 
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * @author Robin Müller
  */
 public interface WebHookAction {
-    void execute(StaplerResponse response);
+    void execute(StaplerResponse2 response);
 }

--- a/src/main/java/com/gitee/jenkins/webhook/build/BuildWebHookAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/BuildWebHookAction.java
@@ -9,15 +9,16 @@ import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+
 import com.gitee.jenkins.trigger.GiteePushTrigger;
 import com.gitee.jenkins.connection.GiteeConnectionConfig;
 import com.gitee.jenkins.webhook.WebHookAction;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
+import org.springframework.security.core.Authentication;
 
 /**
  * @author Xinran Xiao
@@ -25,20 +26,21 @@ import javax.servlet.ServletException;
  */
 abstract class BuildWebHookAction implements WebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(BuildWebHookAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(BuildWebHookAction.class.getName());
 
     abstract void processForCompatibility();
 
     abstract void execute();
 
-    public final void execute(StaplerResponse response) {
+    public final void execute(StaplerResponse2 response) {
         processForCompatibility();
         execute();
     }
 
     public static HttpResponses.HttpResponseException responseWithHook(final WebHook webHook) {
         return new HttpResponses.HttpResponseException() {
-            public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
+            @Override
+            public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node) throws IOException, ServletException {
                 String text = webHook.getWebHookDescription() + " has been accepted.";
                 rsp.setContentType("text/plain;charset=UTF-8");
                 rsp.getWriter().println(text);
@@ -71,8 +73,8 @@ abstract class BuildWebHookAction implements WebHookAction {
         }
 
         private void checkPermission(Permission permission) {
-            if (((GiteeConnectionConfig) Jenkins.getInstance().getDescriptor(GiteeConnectionConfig.class)).isUseAuthenticatedEndpoint()) {
-                if (!Jenkins.getActiveInstance().getACL().hasPermission(authentication, permission)) {
+            if (((GiteeConnectionConfig) Jenkins.get().getDescriptor(GiteeConnectionConfig.class)).isUseAuthenticatedEndpoint()) {
+                if (!Jenkins.get().getACL().hasPermission2(authentication, permission)) {
                     String message = authentication.getName() + " is missing the " + permission.group.title+"/"+permission.name+ " permission";
                     LOGGER.finest("Unauthorized (Did you forget to add API Token to the web hook ?)");
                     throw HttpResponses.errorWithoutStack(403, message);

--- a/src/main/java/com/gitee/jenkins/webhook/build/NoteBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/NoteBuildAction.java
@@ -3,13 +3,12 @@ package com.gitee.jenkins.webhook.build;
 import com.gitee.jenkins.trigger.GiteePushTrigger;
 import com.gitee.jenkins.gitee.hook.model.NoteHook;
 import com.gitee.jenkins.util.JsonUtil;
-import com.gitee.jenkins.webhook.WebHookAction;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerResponse;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -21,7 +20,7 @@ import static com.gitee.jenkins.util.JsonUtil.toPrettyPrint;
  */
 public class NoteBuildAction extends BuildWebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(NoteBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(NoteBuildAction.class.getName());
     private Item project;
     private NoteHook noteHook;
     private final String secretToken;
@@ -44,12 +43,14 @@ public class NoteBuildAction extends BuildWebHookAction {
         if (!(project instanceof Job<?, ?>)) {
             throw HttpResponses.errorWithoutStack(409, "Note Hook is not supported for this project");
         }
-        ACL.impersonate(ACL.SYSTEM, new BuildWebHookAction.TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
-            @Override
-            protected void performOnPost(GiteePushTrigger trigger) {
-                trigger.onPost(noteHook);
-            }
-        });
+        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+            new BuildWebHookAction.TriggerNotifier(project, secretToken, Jenkins.getAuthentication2()) {
+                @Override
+                protected void performOnPost(GiteePushTrigger trigger) {
+                    trigger.onPost(noteHook);
+                }
+            };
+        }
         throw responseWithHook(noteHook);
     }
 }

--- a/src/main/java/com/gitee/jenkins/webhook/build/PipelineBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/PipelineBuildAction.java
@@ -6,6 +6,7 @@ import com.gitee.jenkins.util.JsonUtil;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
@@ -22,7 +23,7 @@ import static com.gitee.jenkins.util.JsonUtil.toPrettyPrint;
  */
 public class PipelineBuildAction extends BuildWebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(PipelineBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(PipelineBuildAction.class.getName());
     private Item project;
     private PipelineHook pipelineBuildHook;
     private final String secretToken;
@@ -57,12 +58,14 @@ public class PipelineBuildAction extends BuildWebHookAction {
         if (!(project instanceof Job<?, ?>)) {
             throw HttpResponses.errorWithoutStack(409, "Pipeline Hook is not supported for this project");
         }
-        ACL.impersonate(ACL.SYSTEM, new TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
-            @Override
-            protected void performOnPost(GiteePushTrigger trigger) {
-                trigger.onPost(pipelineBuildHook);
-            }
-        });
+        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+            new TriggerNotifier(project, secretToken, Jenkins.getAuthentication2()) {
+                @Override
+                protected void performOnPost(GiteePushTrigger trigger) {
+                    trigger.onPost(pipelineBuildHook);
+                }
+            };
+        }
         throw responseWithHook(pipelineBuildHook);
     }
 

--- a/src/main/java/com/gitee/jenkins/webhook/status/BuildPageRedirectAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/status/BuildPageRedirectAction.java
@@ -4,7 +4,7 @@ import com.gitee.jenkins.webhook.WebHookAction;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 
@@ -19,13 +19,13 @@ abstract class BuildPageRedirectAction implements WebHookAction {
         this.build = build;
     }
 
-    public void execute(StaplerResponse response) {
+    public void execute(StaplerResponse2 response) {
         if (build != null) {
             try {
-                response.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getUrl());
+                response.sendRedirect2(Jenkins.get().getRootUrl() + build.getUrl());
             } catch (IOException e) {
                 try {
-                    response.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getBuildStatusUrl());
+                    response.sendRedirect2(Jenkins.get().getRootUrl() + build.getBuildStatusUrl());
                 } catch (IOException e1) {
                     throw HttpResponses.error(500, "Failed to redirect to build page");
                 }

--- a/src/main/java/com/gitee/jenkins/webhook/status/BuildStatusAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/status/BuildStatusAction.java
@@ -8,7 +8,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.util.HttpResponses;
 import jenkins.triggers.SCMTriggerItem;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * @author Robin Müller
@@ -23,7 +23,7 @@ abstract class BuildStatusAction implements WebHookAction {
         this.build = build;
     }
 
-    public void execute(StaplerResponse response) {
+    public void execute(StaplerResponse2 response) {
         SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
         if (!hasGitSCM(item)) {
             throw HttpResponses.error(409, "The project has no GitSCM configured");
@@ -31,7 +31,7 @@ abstract class BuildStatusAction implements WebHookAction {
         writeStatusBody(response, build, getStatus(build));
     }
 
-    protected abstract void writeStatusBody(StaplerResponse response, Run<?, ?> build, BuildStatus status);
+    protected abstract void writeStatusBody(StaplerResponse2 response, Run<?, ?> build, BuildStatus status);
 
     private boolean hasGitSCM(SCMTriggerItem item) {
         if (item != null) {
@@ -63,7 +63,7 @@ abstract class BuildStatusAction implements WebHookAction {
     protected enum BuildStatus {
         NOT_FOUND("not_found"), RUNNING("running"), CANCELED("canceled"), SUCCESS("success"), FAILED("failed"), UNSTABLE("failed");
 
-        private String value;
+        private final String value;
 
         BuildStatus(String value) {
             this.value = value;

--- a/src/main/java/com/gitee/jenkins/webhook/status/StatusJsonAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/status/StatusJsonAction.java
@@ -5,7 +5,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -23,7 +23,7 @@ public class StatusJsonAction extends BuildStatusAction {
     }
 
     @Override
-    protected void writeStatusBody(StaplerResponse response, Run<?, ?> build, BuildStatus status) {
+    protected void writeStatusBody(StaplerResponse2 response, Run<?, ?> build, BuildStatus status) {
         try {
             JSONObject object = new JSONObject();
             object.put("sha", sha1);
@@ -37,7 +37,7 @@ public class StatusJsonAction extends BuildStatusAction {
         }
     }
 
-    private void writeBody(StaplerResponse response, JSONObject body) throws IOException {
+    private void writeBody(StaplerResponse2 response, JSONObject body) throws IOException {
         response.setContentType("application/json");
         PrintWriter writer = response.getWriter();
         writer.write(body.toString());

--- a/src/main/java/com/gitee/jenkins/webhook/status/StatusPngAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/status/StatusPngAction.java
@@ -4,7 +4,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
 import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.InputStream;
 
@@ -17,7 +17,7 @@ class StatusPngAction extends BuildStatusAction {
     }
 
     @Override
-    protected void writeStatusBody(StaplerResponse response, Run<?, ?> build, BuildStatus status) {
+    protected void writeStatusBody(StaplerResponse2 response, Run<?, ?> build, BuildStatus status) {
         try {
             response.setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
             response.setHeader("Cache-Control", "no-cache, private");
@@ -30,17 +30,12 @@ class StatusPngAction extends BuildStatusAction {
     }
 
     private InputStream getStatusImage(BuildStatus status) {
-        switch (status) {
-            case RUNNING:
-                return getClass().getResourceAsStream("running.png");
-            case SUCCESS:
-                return getClass().getResourceAsStream("success.png");
-            case FAILED:
-                return getClass().getResourceAsStream("failed.png");
-            case UNSTABLE:
-                return getClass().getResourceAsStream("unstable.png");
-            default:
-                return getClass().getResourceAsStream("unknown.png");
-        }
+        return switch (status) {
+            case RUNNING -> getClass().getResourceAsStream("running.png");
+            case SUCCESS -> getClass().getResourceAsStream("success.png");
+            case FAILED -> getClass().getResourceAsStream("failed.png");
+            case UNSTABLE -> getClass().getResourceAsStream("unstable.png");
+            default -> getClass().getResourceAsStream("unknown.png");
+        };
     }
 }

--- a/src/main/java/com/gitee/jenkins/workflow/AcceptGiteePullRequestStep.java
+++ b/src/main/java/com/gitee/jenkins/workflow/AcceptGiteePullRequestStep.java
@@ -2,12 +2,14 @@ package com.gitee.jenkins.workflow;
 
 import static com.gitee.jenkins.connection.GiteeConnectionProperty.getClient;
 
+import java.io.Serial;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
@@ -44,7 +46,7 @@ public class AcceptGiteePullRequestStep extends Step {
 	public StepExecution start(StepContext context) throws Exception {
 		return new AcceptGiteePullRequestStepExecution(context, this);
 	}
-	
+
     public String getMergeCommitMessage() {
         return mergeCommitMessage;
     }
@@ -54,7 +56,8 @@ public class AcceptGiteePullRequestStep extends Step {
         this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;
     }
 
-    public static class AcceptGiteePullRequestStepExecution extends AbstractSynchronousStepExecution<Void> {
+    public static class AcceptGiteePullRequestStepExecution extends SynchronousStepExecution<Void> {
+        @Serial
         private static final long serialVersionUID = 1;
 
         private final transient Run<?, ?> run;
@@ -66,7 +69,7 @@ public class AcceptGiteePullRequestStep extends Step {
             this.step = step;
             run = context.get(Run.class);
         }
-        
+
         @Override
         protected Void run() throws Exception {
             GiteeWebHookCause cause = run.getCause(GiteeWebHookCause.class);
@@ -123,6 +126,7 @@ public class AcceptGiteePullRequestStep extends Step {
     @Extension
     public static final class DescriptorImpl extends StepDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Accept Gitee Pull Request";
@@ -132,7 +136,7 @@ public class AcceptGiteePullRequestStep extends Step {
         public String getFunctionName() {
             return "acceptGiteeMR";
         }
-        
+
 		@Override
 		public Set<Class<?>> getRequiredContext() {
 			return ImmutableSet.of(TaskListener.class, Run.class);

--- a/src/main/java/com/gitee/jenkins/workflow/AddGiteePullRequestCommentStep.java
+++ b/src/main/java/com/gitee/jenkins/workflow/AddGiteePullRequestCommentStep.java
@@ -2,20 +2,22 @@ package com.gitee.jenkins.workflow;
 
 import static com.gitee.jenkins.connection.GiteeConnectionProperty.getClient;
 
+import java.io.Serial;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 
 import com.gitee.jenkins.gitee.api.model.PullRequest;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -47,7 +49,7 @@ public class AddGiteePullRequestCommentStep extends Step {
 	public StepExecution start(StepContext context) throws Exception {
 		return new AddGiteePullRequestCommentStepExecution(context, this);
 	}
-	
+
     public String getComment() {
         return comment;
     }
@@ -57,7 +59,8 @@ public class AddGiteePullRequestCommentStep extends Step {
         this.comment = StringUtils.isEmpty(comment) ? null : comment;
     }
 
-    public static class AddGiteePullRequestCommentStepExecution extends AbstractSynchronousStepExecution<Void> {
+    public static class AddGiteePullRequestCommentStepExecution extends SynchronousStepExecution<Void> {
+        @Serial
         private static final long serialVersionUID = 1;
 
         private final transient Run<?, ?> run;
@@ -69,7 +72,7 @@ public class AddGiteePullRequestCommentStep extends Step {
             this.step = step;
             run = context.get(Run.class);
         }
-        
+
         @Override
         protected Void run() throws Exception {
             GiteeWebHookCause cause = run.getCause(GiteeWebHookCause.class);
@@ -126,6 +129,7 @@ public class AddGiteePullRequestCommentStep extends Step {
     @Extension
     public static final class DescriptorImpl extends StepDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Add comment on Gitee Pull Request";
@@ -135,7 +139,7 @@ public class AddGiteePullRequestCommentStep extends Step {
         public String getFunctionName() {
             return "addGiteeMRComment";
         }
-        
+
 		@Override
 		public Set<Class<?>> getRequiredContext() {
 			return ImmutableSet.of(TaskListener.class, Run.class);


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

⚠️ I had to update RESTEasy Client in order to support EE 9. The library was refactored and there are some deprecations that should be adressed in a seperate PR.

### Testing done

⚠️  There is not a single test in this project. I had some manual tests I took from the README and did not notice any errors

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
