### PR TITLE
Translations for pull request trigger values

### DIFF
--- a/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.jelly
+++ b/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.jelly
@@ -17,10 +17,10 @@
 
       <f:entry name="triggerOnUpdatePullRequest" title="${%Updated.Pull.Request}">
         <select name="triggerOnUpdatePullRequest" field="triggerOnUpdatePullRequest">
-          <option value="0" selected = "${(instance.triggerOnUpdatePullRequest.equals('0') || instance.triggerOnUpdatePullRequest.toString().equals('false')) ? 'true':null}">None</option>
-          <option value="3" selected = "${(instance.triggerOnUpdatePullRequest.equals('3') || instance.triggerOnUpdatePullRequest.toString().equals('true')) ? 'true':null}">Both Source and Target Branch updated</option>
-          <option value="1" selected = "${instance.triggerOnUpdatePullRequest.equals('1') ? 'true':null}">Source Branch updated</option>
-          <option value="2" selected = "${instance.triggerOnUpdatePullRequest.equals('2') ? 'true':null}">Target Branch updated</option>
+          <option value="0" selected = "${(instance.triggerOnUpdatePullRequest.equals('0') || instance.triggerOnUpdatePullRequest.toString().equals('false')) ? 'true':null}">${%triggerOnUpdatePullRequest.None}</option>
+          <option value="3" selected = "${(instance.triggerOnUpdatePullRequest.equals('3') || instance.triggerOnUpdatePullRequest.toString().equals('true')) ? 'true':null}">${%triggerOnUpdatePullRequest.Both}</option>
+          <option value="1" selected = "${instance.triggerOnUpdatePullRequest.equals('1') ? 'true':null}">${%triggerOnUpdatePullRequest.Source}</option>
+          <option value="2" selected = "${instance.triggerOnUpdatePullRequest.equals('2') ? 'true':null}">${%triggerOnUpdatePullRequest.Target}</option>
         </select>
       </f:entry>
 

--- a/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.properties
+++ b/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.properties
@@ -44,3 +44,7 @@ Ignore.Pull.Request.Conflicts=Ignore Pull Request conflicts
 Comments=Comment Pull Requests
 Comment.Regex=Comment (regex) for triggering a build
 Retry.Text=Jenkins please retry a build
+triggerOnUpdatePullRequest.None=None
+triggerOnUpdatePullRequest.Both=Both Source and Target Branch updated
+triggerOnUpdatePullRequest.Source=Source Branch updated
+triggerOnUpdatePullRequest.Target=Target Branch updated

--- a/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config_zh_CN.properties
+++ b/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config_zh_CN.properties
@@ -44,3 +44,7 @@ Ignore.Pull.Request.Conflicts=\u5FFD\u7565 Pull Request \u51B2\u7A81
 Comments=\u8BC4\u8BBA Pull Requests
 Comment.Regex=\u8BC4\u8BBA\u5185\u5BB9\u7684\u6B63\u5219\u8868\u8FBE\u5F0F
 Retry.Text=Jenkins please retry a build
+triggerOnUpdatePullRequest.None=没有
+triggerOnUpdatePullRequest.Both=源分支和目标分支都已更新
+triggerOnUpdatePullRequest.Source=源分支已更新
+triggerOnUpdatePullRequest.Target=目标分支已更新


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Verified localization via browser settings

Pull request trigger values had no translation in `config_zh_CN.properties`. I have added those values and confirmed in the codebase that the `value` and inner tag string were separate, and `value` was the property that mattered (so that no string mismatching happened). 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

