### PR TITLE
Add BuildWebHookActionTest.java

### DIFF
--- a/src/main/java/com/gitee/jenkins/connection/GiteeConnectionConfig.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeConnectionConfig.java
@@ -61,7 +61,7 @@ public class GiteeConnectionConfig extends GlobalConfiguration {
         return useAuthenticatedEndpoint;
     }
 
-    void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
+    public void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
         this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
     }
 

--- a/src/test/java/com/gitee/jenkins/connection/GiteeConnectionTest.java
+++ b/src/test/java/com/gitee/jenkins/connection/GiteeConnectionTest.java
@@ -1,3 +1,8 @@
+/**
+ * Adapted from GitLab automated tests
+ * https://github.com/jenkinsci/gitlab-plugin/tree/master/src/test/java/com/dabsquared/gitlabjenkins
+ */
+
 package com.gitee.jenkins.connection;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/com/gitee/jenkins/webhook/build/BuildWebHookActionTest.java
+++ b/src/test/java/com/gitee/jenkins/webhook/build/BuildWebHookActionTest.java
@@ -1,0 +1,127 @@
+/**
+ * Adapted from GitLab automated tests
+ * https://github.com/jenkinsci/gitlab-plugin/tree/master/src/test/java/com/dabsquared/gitlabjenkins
+ */
+
+package com.gitee.jenkins.webhook.build;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.HttpResponses.HttpResponseException;
+import org.springframework.security.core.Authentication;
+
+import com.gitee.jenkins.connection.GiteeConnectionConfig;
+import com.gitee.jenkins.trigger.GiteePushTrigger;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Project;
+import hudson.security.ACL;
+
+
+/**
+ * Test the BuildWebHookAction class
+ *
+ * @author Mark Waite
+ */
+@WithJenkins
+public class BuildWebHookActionTest {
+    private JenkinsRule j;
+
+    private FreeStyleProject project;
+    private GiteePushTrigger trigger;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
+        j.get(GiteeConnectionConfig.class).setUseAuthenticatedEndpoint(true);
+
+        project = j.createFreeStyleProject();
+        trigger = new GiteePushTrigger();
+        project.addTrigger(trigger);
+    }
+
+    @Test
+    void testNotifierTokenMatches() {
+        String triggerToken = "testNotifierTokenMatches-token";
+        trigger.setSecretToken(triggerToken);
+        String actionToken = triggerToken;
+        BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
+        action.runNotifier();
+        assertTrue(action.performOnPostCalled, "performOnPost not called, token did not match?");
+    }
+
+    @Test
+        void testNotifierTokenDoesNotMatchString() {
+        String triggerToken = "testNotifierTokenDoesNotMatchString-token";
+        trigger.setSecretToken(triggerToken);
+        String actionToken = triggerToken + "-no-match"; // Won't match
+        BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
+        assertThrows(HttpResponseException.class, action::runNotifier);
+        assertFalse(action.performOnPostCalled, "performOnPost was called, unexpected token match?");
+    }
+
+    @Test
+    void testNotifierTokenDoesNotMatchNull() {
+        String triggerToken = "testNotifierTokenDoesNotMatchNull-token";
+        trigger.setSecretToken(triggerToken);
+        String actionToken = null;
+        BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
+        assertThrows(HttpResponseException.class, action::runNotifier);
+        assertFalse(action.performOnPostCalled, "performOnPost was called, unexpected token match?");
+    }
+
+    @Test
+    void testNullNotifierTokenAllowsAccess() {
+        assertNull(trigger.getSecretToken());
+        String actionToken = "testNullNotifierTokenAllowsAccess-token";
+        BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
+        action.runNotifier();
+        assertTrue(action.performOnPostCalled, "performOnPost not called, token did not match?");
+    }
+
+    public class BuildWebHookActionImpl extends BuildWebHookAction {
+
+        // Used for the assertion that tokenMatches() returned true
+        public boolean performOnPostCalled = false;
+
+        private final MyTriggerNotifier myNotifier;
+
+        public BuildWebHookActionImpl() {
+            myNotifier = new MyTriggerNotifier(null, null, null);
+        }
+
+        public BuildWebHookActionImpl(@NonNull Project project, @NonNull String token) {
+            myNotifier = new MyTriggerNotifier(project, token, ACL.SYSTEM2);
+        }
+
+        public void runNotifier() {
+            myNotifier.run();
+        }
+
+        public class MyTriggerNotifier extends TriggerNotifier {
+
+            public MyTriggerNotifier(Item project, String secretToken, Authentication authentication) {
+                super(project, secretToken, authentication);
+            }
+
+            @Override
+            protected void performOnPost(GiteePushTrigger trigger) {
+                performOnPostCalled = true;
+            }
+        }
+
+        @Override
+        public void processForCompatibility() {}
+
+        @Override
+        public void execute() {}
+    }
+}


### PR DESCRIPTION
Added automated tests for `BuildWebHookActionTest.java`, adapted from GitLab.
    - Added BuildWebHookActionTest.java
    - Comment in GiteeConnectionTest.java
    - Modified GiteeConnectionConfig.java to work with changes

### Testing done
Built and tested successfully on machine (Ubuntu 24)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
