### PR TITLE
Add GiteeAcceptPullRequestPublisherTest.java and TestUtility.java

### DIFF
--- a/src/test/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisherTest.java
+++ b/src/test/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisherTest.java
@@ -1,3 +1,8 @@
+/**
+ * Adapted from GitLab automated tests
+ * https://github.com/jenkinsci/gitlab-plugin/tree/master/src/test/java/com/dabsquared/gitlabjenkins
+ */
+
 package com.gitee.jenkins.publisher;
 
 import static org.mockserver.model.HttpRequest.request;

--- a/src/test/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisherTest.java
+++ b/src/test/java/com/gitee/jenkins/publisher/GiteeAcceptPullRequestPublisherTest.java
@@ -1,0 +1,99 @@
+package com.gitee.jenkins.publisher;
+
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import static com.gitee.jenkins.publisher.TestUtility.GITEE_CONNECTION_V5;
+import static com.gitee.jenkins.publisher.TestUtility.PULL_REQUEST_ID;
+import static com.gitee.jenkins.publisher.TestUtility.PULL_REQUEST_IID;
+import static com.gitee.jenkins.publisher.TestUtility.REPO_PATH;
+import static com.gitee.jenkins.publisher.TestUtility.PROJECT_ID;
+import static com.gitee.jenkins.publisher.TestUtility.mockSimpleBuild;
+import static com.gitee.jenkins.publisher.TestUtility.preparePublisher;
+import static com.gitee.jenkins.publisher.TestUtility.setupGiteeConnections;
+import static com.gitee.jenkins.publisher.TestUtility.verifyMatrixAggregatable;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.StreamBuildListener;
+import java.nio.charset.Charset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.model.HttpRequest;
+
+/**
+ * @author Nikolay Ustinov
+ */
+@WithJenkins
+@ExtendWith(MockServerExtension.class)
+class GiteeAcceptPullRequestPublisherTest {
+
+    private static JenkinsRule jenkins;
+
+    private static MockServerClient mockServerClient;
+    private BuildListener listener;
+
+    @BeforeAll
+    static void setUp(JenkinsRule rule, MockServerClient client) throws Exception {
+        jenkins = rule;
+        mockServerClient = client;
+        setupGiteeConnections(jenkins, client);
+    }
+
+    @BeforeEach
+    void setUp() {
+        listener = new StreamBuildListener(jenkins.createTaskListener().getLogger(), Charset.defaultCharset());
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServerClient.reset();
+    }
+
+    @Test
+    void matrixAggregatable() throws Exception {
+        verifyMatrixAggregatable(GiteeAcceptPullRequestPublisher.class, listener);
+    }
+
+    @Test
+    void success() throws Exception {
+        publish(mockSimpleBuild(GITEE_CONNECTION_V5, Result.SUCCESS));
+
+        mockServerClient.verify(
+                prepareAcceptPullRequestWithSuccessResponse("v5", PULL_REQUEST_IID, null));
+    }
+
+    @Test
+    void failed() throws Exception {
+        publish(mockSimpleBuild(GITEE_CONNECTION_V5, Result.FAILURE));
+
+        mockServerClient.verifyZeroInteractions();
+    }
+
+    private void publish(AbstractBuild build) throws Exception {
+        GiteeAcceptPullRequestPublisher publisher = preparePublisher(new GiteeAcceptPullRequestPublisher(), build);
+        publisher.perform(build, null, listener);
+    }
+
+    private HttpRequest prepareAcceptPullRequestWithSuccessResponse(
+            String apiLevel, int pullRequestId, Boolean shouldRemoveSourceBranch) {
+        HttpRequest updateCommitStatus = prepareAcceptPullRequest(apiLevel, pullRequestId, shouldRemoveSourceBranch);
+        mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
+        return updateCommitStatus;
+    }
+
+    private HttpRequest prepareAcceptPullRequest(String apiLevel, int pullRequestId, Boolean removeSourceBranch) {
+        return request()
+                .withPath(String.format("/gitee/api/%s/repos/%d/%s/pulls/%d/merge", apiLevel, PROJECT_ID, REPO_PATH, pullRequestId))
+                .withMethod("PUT")
+                .withHeader("PRIVATE-TOKEN", "secret");
+    }
+}

--- a/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
+++ b/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
@@ -1,3 +1,8 @@
+/**
+ * Adapted from GitLab automated tests
+ * https://github.com/jenkinsci/gitlab-plugin/tree/master/src/test/java/com/dabsquared/gitlabjenkins
+ */
+
 package com.gitee.jenkins.publisher;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
+++ b/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
@@ -1,0 +1,134 @@
+package com.gitee.jenkins.publisher;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.gitee.jenkins.connection.GiteeConnection;
+import com.gitee.jenkins.connection.GiteeConnectionConfig;
+import com.gitee.jenkins.connection.GiteeConnectionProperty;
+import com.gitee.jenkins.gitee.api.impl.GiteeV5ClientBuilder;
+import com.gitee.jenkins.gitee.api.model.PullRequest;
+
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixConfiguration;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.plugins.git.util.BuildData;
+import hudson.tasks.Notifier;
+import hudson.util.Secret;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockserver.client.MockServerClient;
+
+final class TestUtility {
+    static final String GITEE_CONNECTION_V5 = "GiteeV5";
+    static final String BUILD_URL = "/build/123";
+    static final String REPO_PATH = "testPath";
+    static final String PULL_COMMIT_SHA = "eKJ3wuqJT98Kc8TCcBK7oggLR1E9Bty7eqSHfSLT";
+    static final int BUILD_NUMBER = 1;
+    static final int PROJECT_ID = 3;
+    static final int PULL_REQUEST_ID = 1;
+    static final int PULL_REQUEST_IID = 2;
+
+    private static final String API_TOKEN = "secret";
+
+    static void setupGiteeConnections(JenkinsRule jenkins, MockServerClient client) throws Exception {
+        GiteeConnectionConfig connectionConfig = jenkins.get(GiteeConnectionConfig.class);
+        String apiTokenId = "apiTokenId";
+        for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstanceOrNull())) {
+            if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
+                List<Domain> domains = credentialsStore.getDomains();
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                apiTokenId,
+                                "Gitee API Token",
+                                Secret.fromString(TestUtility.API_TOKEN)));
+            }
+        }
+        connectionConfig.addConnection(new GiteeConnection(
+                TestUtility.GITEE_CONNECTION_V5,
+                "http://localhost:" + client.getPort() + "/gitee",
+                apiTokenId,
+                new GiteeV5ClientBuilder(),
+                false,
+                10,
+                10));
+    }
+
+    static <T extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(
+            Class<T> publisherClass, BuildListener listener) throws Exception {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractProject project = mock(MatrixConfiguration.class);
+        Notifier publisher = mock(publisherClass);
+        MatrixBuild parentBuild = mock(MatrixBuild.class);
+
+        when(build.getParent()).thenReturn(project);
+        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(), any(BuildListener.class)))
+                .thenCallRealMethod();
+        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class)))
+                .thenReturn(true);
+
+        MatrixAggregator aggregator = ((MatrixAggregatable) publisher).createAggregator(parentBuild, null, listener);
+        aggregator.startBuild();
+        aggregator.endBuild();
+        verify(publisher).perform(parentBuild, null, listener);
+    }
+
+    static AbstractBuild mockSimpleBuild(String gitLabConnection, Result result, String... remoteUrls) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        BuildData buildData = mock(BuildData.class);
+        when(buildData.getRemoteUrls()).thenReturn(new HashSet<>(Arrays.asList(remoteUrls)));
+        when(build.getAction(BuildData.class)).thenReturn(buildData);
+        when(build.getResult()).thenReturn(result);
+        when(build.getUrl()).thenReturn(BUILD_URL);
+        when(build.getResult()).thenReturn(result);
+        when(build.getNumber()).thenReturn(BUILD_NUMBER);
+
+        AbstractProject<?, ?> project = mock(AbstractProject.class);
+        when(project.getProperty(GiteeConnectionProperty.class))
+                .thenReturn(new GiteeConnectionProperty(gitLabConnection));
+        doReturn(project).when(build).getParent();
+        doReturn(project).when(build).getProject();
+        return build;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    static String formatNote(AbstractBuild build, String note) {
+        String buildUrl = Jenkins.getInstanceOrNull().getRootUrl() + build.getUrl();
+        return MessageFormat.format(
+                note, build.getResult(), build.getParent().getDisplayName(), BUILD_NUMBER, buildUrl);
+    }
+
+    static <P extends PullRequestNotifier> P preparePublisher(P publisher, AbstractBuild build) {
+        P spyPublisher = spy(publisher);
+        PullRequest mergeRequest = new PullRequest(
+                PULL_REQUEST_ID, PULL_REQUEST_IID, PULL_COMMIT_SHA, "", "", PROJECT_ID, PROJECT_ID, "", "", String.format("%d/%s", PROJECT_ID, REPO_PATH));
+        doReturn(mergeRequest).when(spyPublisher).getPullRequest(build);
+        return spyPublisher;
+    }
+
+    private TestUtility() {
+        /* contains only static utility-methods */
+    }
+}


### PR DESCRIPTION
Added GiteeAcceptPullRequestPublisherTest.java and TestUtility.java. Adapted from GitLab automated tests. Automated tests that check behavior of when pull request should be accepted to be merged on Gitee.
### Testing done
Ran on my machine (Ubuntu 24.04) with `mvn test`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
