### PR TITLE
Added PushBuildActionTest.java

### DIFF
--- a/src/test/java/com/gitee/jenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/gitee/jenkins/webhook/build/PushBuildActionTest.java
@@ -1,0 +1,132 @@
+package com.gitee.jenkins.webhook.build;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gitee.jenkins.trigger.GiteePushTrigger;
+import com.gitee.jenkins.gitee.hook.model.PushHook;
+import hudson.model.FreeStyleProject;
+import hudson.security.ACL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
+import jenkins.scm.api.SCMSourceOwner;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * @author Robin Müller
+ */
+@WithJenkins
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PushBuildActionTest {
+
+    private static JenkinsRule jenkins;
+
+    @Mock
+    private StaplerResponse2 response;
+
+    @Mock
+    private GiteePushTrigger trigger;
+
+    @BeforeAll
+    static void setUp(JenkinsRule rule) {
+        jenkins = rule;
+    }
+
+    @Test
+    void skip_missingRepositoryUrl() throws Exception {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        testProject.addTrigger(trigger);
+
+        new PushBuildAction(testProject, getJson("PushEvent_missingRepositoryUrl.json"), null).execute(response);
+
+        verify(trigger, never()).onPost(any(PushHook.class));
+    }
+
+    @Test
+    void build() {
+        assertThrows(HttpResponses.HttpResponseException.class, () -> {
+            try {
+                FreeStyleProject testProject = jenkins.createFreeStyleProject();
+                testProject.addTrigger(trigger);
+
+                // exception.expect(HttpResponses.HttpResponseException.class);
+                new PushBuildAction(testProject, getJson("PushEvent.json"), null).execute(response);
+            } finally {
+                ArgumentCaptor<PushHook> pushHookArgumentCaptor = ArgumentCaptor.forClass(PushHook.class);
+                verify(trigger).onPost(pushHookArgumentCaptor.capture());
+                assertThat(pushHookArgumentCaptor.getValue().getProject(), is(notNullValue()));
+                assertThat(pushHookArgumentCaptor.getValue().getProject().getWebUrl(), is(notNullValue()));
+            }
+        });
+    }
+
+    @Test
+    void invalidToken() {
+        assertThrows(HttpResponses.HttpResponseException.class, () -> {
+            FreeStyleProject testProject = jenkins.createFreeStyleProject();
+            when(trigger.getSecretToken()).thenReturn("secret");
+            testProject.addTrigger(trigger);
+            new PushBuildAction(testProject, getJson("PushEvent.json"), "wrong-secret").execute(response);
+
+            verify(trigger, never()).onPost(any(PushHook.class));
+        });
+    }
+
+    private String getJson(String name) throws Exception {
+        return IOUtils.toString(getClass().getResourceAsStream(name), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void scmSourceOnUpdateExecuted() {
+        GitSCMSource source = new GitSCMSource("http://test");
+        SCMSourceOwner item = mock(SCMSourceOwner.class);
+        ACL acl = mock(ACL.class);
+        when(item.getSCMSources()).thenReturn(Collections.singletonList(source));
+        when(item.getACL()).thenReturn(acl);
+        assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
+        // item.onSCMSourceUpdated(source);
+        verify(item).onSCMSourceUpdated(isA(GitSCMSource.class));
+    }
+
+
+    // Test is currently unsupported. A check is missing in the SCMSourceOwnerNotifier.
+    @Test
+    @Disabled
+    void scmSourceOnUpdateNotExecuted() {
+        GitSCMSource source = new GitSCMSource("http://test");
+        source.getTraits().add(new IgnoreOnPushNotificationTrait());
+        SCMSourceOwner item = mock(SCMSourceOwner.class);
+        when(item.getSCMSources()).thenReturn(Collections.singletonList(source));
+        assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
+        verify(item, never()).onSCMSourceUpdated(isA(GitSCMSource.class));
+    }
+}

--- a/src/test/resources/com/gitee/jenkins/webhook/build/PushEvent.json
+++ b/src/test/resources/com/gitee/jenkins/webhook/build/PushEvent.json
@@ -1,0 +1,72 @@
+{
+  "object_kind": "push",
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "user_id": 4,
+  "user_name": "John Smith",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
+  "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
+  "project_id": 15,
+  "project": {
+    "id": 2,
+    "name": "Diaspora",
+    "description": "",
+    "web_url": "http://example.com/mike/diaspora",
+    "avatar_url": null,
+    "ssh_url": "git@example.com:mike/diaspora.git",
+    "git_http_url": "http://example.com/mike/diaspora.git",
+    "namespace": "Mike",
+    "path_with_namespace": "mike/diaspora",
+    "default_branch": "master",
+    "homepage": "http://example.com/mike/diaspora",
+    "url": "git@example.com:mike/diasporadiaspora.git"
+  },
+  "repository": {
+    "name": "Diaspora",
+    "url": "git@example.com:mike/diasporadiaspora.git",
+    "description": "",
+    "homepage": "http://example.com/mike/diaspora",
+    "git_http_url": "http://example.com/mike/diaspora.git",
+    "git_ssh_url": "git@example.com:mike/diaspora.git",
+    "visibility_level": 0
+  },
+  "commits": [
+    {
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update Catalan translation to e38cb41.",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi Mallach",
+        "email": "jordi@softcatala.org"
+      },
+      "added": [
+        "CHANGELOG"
+      ],
+      "modified": [
+        "app/controller/application.rb"
+      ],
+      "removed": []
+    },
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "Gitee dev user",
+        "email": "Giteedev@dv6700.(none)"
+      },
+      "added": [
+        "CHANGELOG"
+      ],
+      "modified": [
+        "app/controller/application.rb"
+      ],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 4
+}

--- a/src/test/resources/com/gitee/jenkins/webhook/build/PushEvent_missingRepositoryUrl.json
+++ b/src/test/resources/com/gitee/jenkins/webhook/build/PushEvent_missingRepositoryUrl.json
@@ -1,0 +1,71 @@
+{
+  "object_kind": "push",
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "user_id": 4,
+  "user_name": "John Smith",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
+  "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
+  "project_id": 15,
+  "project": {
+    "id": 2,
+    "name": "Diaspora",
+    "description": "",
+    "web_url": "http://example.com/mike/diaspora",
+    "avatar_url": null,
+    "ssh_url": "git@example.com:mike/diaspora.git",
+    "git_http_url": "http://example.com/mike/diaspora.git",
+    "namespace": "Mike",
+    "path_with_namespace": "mike/diaspora",
+    "default_branch": "master",
+    "homepage": "http://example.com/mike/diaspora",
+    "url": "git@example.com:mike/diasporadiaspora.git"
+  },
+  "repository": {
+    "name": "Diaspora",
+    "description": "",
+    "homepage": "http://example.com/mike/diaspora",
+    "git_http_url": "http://example.com/mike/diaspora.git",
+    "git_ssh_url": "git@example.com:mike/diaspora.git",
+    "visibility_level": 0
+  },
+  "commits": [
+    {
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update Catalan translation to e38cb41.",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi Mallach",
+        "email": "jordi@softcatala.org"
+      },
+      "added": [
+        "CHANGELOG"
+      ],
+      "modified": [
+        "app/controller/application.rb"
+      ],
+      "removed": []
+    },
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "Gitee dev user",
+        "email": "Giteedev@dv6700.(none)"
+      },
+      "added": [
+        "CHANGELOG"
+      ],
+      "modified": [
+        "app/controller/application.rb"
+      ],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 4
+}


### PR DESCRIPTION
Created `PushBuildActionTest.java`. Skipping `scmSourceOnUpdateNotExecuted()` test because of differing implementation, but may consider implementing `IgnoreOnPushNotificationTrait` check later.

### Testing done
Ran on my locally running Jenkins server on Ubuntu 24.04.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
