### PR TITLE
Added ProjectIdUtilTest.java and GiteeClientStub.java, fixed edge cases

### DIFF
--- a/src/main/java/com/gitee/jenkins/util/ProjectIdUtil.java
+++ b/src/main/java/com/gitee/jenkins/util/ProjectIdUtil.java
@@ -23,6 +23,11 @@ public final class ProjectIdUtil {
             String projectId;
             if (baseUri != null && remoteUrl.startsWith(baseUri)) {
                 projectId = new URIish(remoteUrl.substring(baseUri.length())).getPath();
+                if (projectId.contains(":")) {
+                    projectId = projectId.substring(projectId.indexOf(":"));
+                } else if (projectId.startsWith(".")) {
+                    projectId = projectId.substring(projectId.indexOf("/"));
+                }
             } else {
                 projectId = new URIish(remoteUrl).getPath();
             }

--- a/src/test/java/com/gitee/jenkins/util/GiteeClientStub.java
+++ b/src/test/java/com/gitee/jenkins/util/GiteeClientStub.java
@@ -1,0 +1,30 @@
+package com.gitee.jenkins.util;
+
+import com.gitee.jenkins.gitee.api.GiteeClient;
+import com.gitee.jenkins.gitee.api.model.PullRequest;
+import com.gitee.jenkins.gitee.api.model.User;
+
+class GiteeClientStub implements GiteeClient {
+    private final String url;
+
+    GiteeClientStub(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String getHostUrl() {
+        return url;
+    }
+
+    @Override
+    public void acceptPullRequest(PullRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch) {}
+
+    @Override
+    public void createPullRequestNote(PullRequest mr, String body) {}
+
+    @Override
+    public User getCurrentUser() {
+        return null;
+    }
+}
+

--- a/src/test/java/com/gitee/jenkins/util/ProjectIdUtilTest.java
+++ b/src/test/java/com/gitee/jenkins/util/ProjectIdUtilTest.java
@@ -1,0 +1,74 @@
+package com.gitee.jenkins.util;
+
+import static com.gitee.jenkins.util.ProjectIdUtilTest.TestData.forRemoteUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.gitee.jenkins.gitee.api.GiteeClient;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Robin Müller
+ */
+class ProjectIdUtilTest {
+
+    static TestData[] data() {
+        return new TestData[] {
+            forRemoteUrl("git@gitee.com", "git@gitee.com:test/project.git").expectProjectId("test/project"),
+            forRemoteUrl("https://gitee.com", "https://gitee.com/test/project.git")
+                    .expectProjectId("test/project"),
+            forRemoteUrl("https://myurl.com/gitee", "https://myurl.com/gitee/group/project.git")
+                    .expectProjectId("group/project"),
+            forRemoteUrl("git@gitee.com", "git@gitee.com:group/subgroup/project.git")
+                    .expectProjectId("group/subgroup/project"),
+            forRemoteUrl("https://myurl.com/gitee", "https://myurl.com/gitee/group/subgroup/project.git")
+                    .expectProjectId("group/subgroup/project"),
+            forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/project.git")
+                    .expectProjectId("group/subgroup/project"),
+            forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/subsubgroup/project.git")
+                    .expectProjectId("group/subgroup/subsubgroup/project"),
+            forRemoteUrl("git@gitee.com", "git@gitee.com:group/subgroup/subsubgroup/project.git")
+                    .expectProjectId("group/subgroup/subsubgroup/project"),
+            forRemoteUrl("http://myhost", "http://myhost.com/group/project.git").expectProjectId("group/project"),
+            forRemoteUrl("", "http://myhost.com/group/project.git").expectProjectId("group/project"),
+            forRemoteUrl("", "http://myhost.com:group/project.git").expectProjectId("group/project"),
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    void retrieveProjectId(TestData testData) throws Exception {
+        GiteeClient client = new GiteeClientStub(testData.hostUrl);
+
+        String projectId = ProjectIdUtil.retrieveProjectId(client, testData.remoteUrl);
+
+        assertThat(projectId, is(testData.expectedProjectId));
+    }
+
+    static final class TestData {
+
+        private final String hostUrl;
+        private final String remoteUrl;
+        private String expectedProjectId;
+
+        private TestData(String hostUrl, String remoteUrl) {
+            this.hostUrl = hostUrl;
+            this.remoteUrl = remoteUrl;
+        }
+
+        private TestData expectProjectId(String expectedProjectId) {
+            this.expectedProjectId = expectedProjectId;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return remoteUrl;
+        }
+
+        static TestData forRemoteUrl(String baseUrl, String remoteUrl) {
+            return new TestData(baseUrl, remoteUrl);
+        }
+    }
+}


### PR DESCRIPTION
Added `ProjectIdUtilTest.java` and `GiteeClientStub.java`, fixed edge cases with `:` characters and `.com` in `projectId` .

<!-- Please describe your pull request here. -->

### Testing done
Ran and compiled on Ubuntu 24. All test cases passed.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
