### PR TITLE
Add pullRequest_do_not_build_when_is_not_mergeable_client_response()

### DIFF
--- a/src/test/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImplTest.java
@@ -11,6 +11,10 @@ import static com.gitee.jenkins.trigger.handler.pull.PullRequestHookTriggerHandl
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import com.gitee.jenkins.connection.GiteeConnectionProperty;
+import com.gitee.jenkins.gitee.api.GiteeClient;
+import com.gitee.jenkins.gitee.api.model.PullRequest;
+import com.gitee.jenkins.gitee.api.model.User;
 import com.gitee.jenkins.gitee.hook.model.Action;
 import com.gitee.jenkins.gitee.hook.model.ActionDesc;
 import com.gitee.jenkins.gitee.hook.model.PullRequestHook;
@@ -18,6 +22,7 @@ import com.gitee.jenkins.gitee.hook.model.State;
 import com.gitee.jenkins.gitee.hook.model.builder.generated.BranchDataBuilder;
 import com.gitee.jenkins.gitee.hook.model.builder.generated.PullRequestHookBuilder;
 import com.gitee.jenkins.gitee.hook.model.builder.generated.PullRequestObjectAttributesBuilder;
+import com.gitee.jenkins.publisher.GiteeMessagePublisher;
 import com.gitee.jenkins.trigger.filter.BranchFilterFactory;
 import com.gitee.jenkins.trigger.filter.BranchFilterType;
 import com.gitee.jenkins.trigger.filter.BuildInstructionFilterType;
@@ -42,6 +47,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Robin Müller
@@ -89,6 +96,37 @@ class PullRequestHookTriggerHandlerImplTest {
 
         assertThat(buildTriggered.isSignaled(), is(true));
         jenkins.assertBuildStatusSuccess(jenkins.waitForCompletion(buildHolder.get()));
+    }
+
+    @Test
+    void pullRequest_do_not_build_when_is_not_mergeable_client_response() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        
+        MockedStatic<GiteeConnectionProperty> config = Mockito.mockStatic(GiteeConnectionProperty.class);
+        MockedStatic<GiteeMessagePublisher> publisher = Mockito.mockStatic(GiteeMessagePublisher.class);
+        TestGiteeClient client = new TestGiteeClient();
+
+        config.when(() -> GiteeConnectionProperty.getClient(project)).thenReturn(client);
+        publisher.when(() -> GiteeMessagePublisher.getFromJob(project)).thenReturn(new TestPublisher());
+        
+        PullRequestHookTriggerHandler pullRequestHookTriggerHandler = newPullRequestHookTriggerHandler(
+                true,
+                "1",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false);
+                
+        final AtomicReference<FreeStyleBuild> buildHolder = new AtomicReference<>();
+        OneShotEvent buildTriggered = doHandle(pullRequestHookTriggerHandler, State.opened, Action.open, buildHolder, false, project);
+
+        assertThat(buildTriggered.isSignaled(), is(false));
+        assertThat(client.getMessage(), is(":bangbang: This pull request can not be merge! The build will not be triggered. Please manual merge conflict."));
     }
 
     @Test
@@ -713,7 +751,9 @@ class PullRequestHookTriggerHandlerImplTest {
         return doHandle(
                 pullRequestHookTriggerHandler,
                 pullRequestHook().withAction(action),
-                buildHolder);
+                buildHolder,
+                true,
+                null);
     }
 
     private OneShotEvent doHandle(
@@ -724,7 +764,9 @@ class PullRequestHookTriggerHandlerImplTest {
         return doHandle(
                 pullRequestHookTriggerHandler,
                 pullRequestHook().withState(state),
-                buildHolder);
+                buildHolder,
+                true,
+                null);
     }
 
     private OneShotEvent doHandle(
@@ -736,7 +778,9 @@ class PullRequestHookTriggerHandlerImplTest {
         return doHandle(
                 pullRequestHookTriggerHandler,
                 pullRequestHook().withState(state).withAction(action),
-                buildHolder);
+                buildHolder,
+                true,
+                null);
     }
 
     private OneShotEvent doHandle(
@@ -749,13 +793,33 @@ class PullRequestHookTriggerHandlerImplTest {
         return doHandle(
                 pullRequestHookTriggerHandler,
                 pullRequestHook().withState(state).withAction(action).withActionDesc(desc),
-                buildHolder);
+                buildHolder,
+                true,
+                null);
     }
 
     private OneShotEvent doHandle(
             PullRequestHookTriggerHandler pullRequestHookTriggerHandler,
+            State state,
+            Action action,
+            AtomicReference<FreeStyleBuild> buildHolder,
+            boolean isMergeable,
+            FreeStyleProject project)
+            throws Exception {
+        return doHandle(
+                pullRequestHookTriggerHandler,
+                pullRequestHook().withState(state).withAction(action),
+                buildHolder,
+                isMergeable,
+                project);
+     }
+
+    private OneShotEvent doHandle(
+            PullRequestHookTriggerHandler pullRequestHookTriggerHandler,
             PullRequestHookBuilder builder,
-            AtomicReference<FreeStyleBuild> buildHolder)
+            AtomicReference<FreeStyleBuild> buildHolder,
+            boolean isMergeable,
+            FreeStyleProject project)
             throws Exception {
         Git.init().setDirectory(tmp).call();
         File.createTempFile("test", null, tmp);
@@ -766,7 +830,9 @@ class PullRequestHookTriggerHandlerImplTest {
         String repositoryUrl = tmp.toURI().toString();
 
         final OneShotEvent buildTriggered = new OneShotEvent();
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        if (project == null) {
+            project = jenkins.createFreeStyleProject();
+        }
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
@@ -780,7 +846,7 @@ class PullRequestHookTriggerHandlerImplTest {
         PullRequestHook hook = builder
                         .withPullRequest(defaultPullRequestObjectAttributes(("refs/heads/" + git.nameRev().add(head).call().get(head)))
                                 .withMergeCommitSha(commit.getName())
-                                .withMergeable(true)
+                                .withMergeable(isMergeable)
                                 .build()) 
                         .withRepo(project()
                                 .withId(3)
@@ -838,6 +904,7 @@ class PullRequestHookTriggerHandlerImplTest {
                                 .withUrl("git@gitee.com:test.git")
                                 .withSshUrl("git@gitee.com:test.git")
                                 .withGitHttpUrl("https://gitee.com/test.git")
+                                .withPathWithNamespace("/test")
                                 .build())
                         .withPullRequest(defaultPullRequestObjectAttributes("test")
                                 .withBody(MRDescription)
@@ -867,6 +934,7 @@ class PullRequestHookTriggerHandlerImplTest {
                                 .withUrl("git@gitee.com:test.git")
                                 .withSshUrl("git@gitee.com:test.git")
                                 .withGitHttpUrl("https://gitee.com/test.git")
+                                .withPathWithNamespace("/test")
                                 .build());
                                 
         if (ref != null && !ref.equals("")) {
@@ -891,8 +959,47 @@ class PullRequestHookTriggerHandlerImplTest {
                                 .withUrl("git@gitee.com:test.git")
                                 .withSshUrl("git@gitee.com:test.git")
                                 .withGitHttpUrl("https://gitee.com/test.git")
+                                .withPathWithNamespace("/test")
                                 .build())
                         .build())
                 .withHead(headBuilder.build());
+    }
+
+    private class TestGiteeClient implements GiteeClient {
+        private String message;
+
+        public TestGiteeClient() {
+
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public String getHostUrl() {
+            throw new UnsupportedOperationException("Unimplemented method 'getHostUrl'");
+        }
+
+        @Override
+        public void acceptPullRequest(PullRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch) {
+            throw new UnsupportedOperationException("Unimplemented method 'acceptPullRequest'");
+        }
+
+        @Override
+        public void createPullRequestNote(PullRequest mr, String body) {
+            message = body;
+        }
+
+        @Override
+        public User getCurrentUser() {
+            throw new UnsupportedOperationException("Unimplemented method 'getCurrentUser'");
+        }
+    }
+
+    private class TestPublisher extends GiteeMessagePublisher {
+        public TestPublisher() {
+            super();
+        }
     }
 }


### PR DESCRIPTION
Add `pullRequest_do_not_build_when_is_not_mergeable_client_response()`, which test case where the pull request is marked as not mergeable. Does not break other tests.
### Testing done
Ran on Ubuntu 24 machine with all `PullRequestHookTriggerHandlerImplTest.java` tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
