### PR TITLE
Added tests for GiteeCreatePullRequestPublisher.java and small bug fix

### DIFF
--- a/src/main/java/com/gitee/jenkins/publisher/GiteeCreatePullRequestPublisher.java
+++ b/src/main/java/com/gitee/jenkins/publisher/GiteeCreatePullRequestPublisher.java
@@ -20,6 +20,7 @@ import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -112,9 +113,12 @@ public class GiteeCreatePullRequestPublisher extends Notifier implements MatrixA
         if (addDatetime) {
             pullRequestTitle = LocalDateTime.now().toString() + title;
         }
-        client.createPullRequest(owner, repo, pullRequestTitle, base, head);
 
-        LOGGER.log(Level.INFO, "Pull request {0} generated, {1} -> {2}", LoggerUtil.toArray(title, head, base));
+        if (build.getResult() == Result.SUCCESS) {
+            client.createPullRequest(owner, repo, pullRequestTitle, base, head);
+            LOGGER.log(Level.INFO, "Pull request {0} generated, {1} -> {2}", LoggerUtil.toArray(title, head, base));
+        }
+        
         return true;
     }
 

--- a/src/test/java/com/gitee/jenkins/publisher/GiteeCreatePullRequestPublisherTest.java
+++ b/src/test/java/com/gitee/jenkins/publisher/GiteeCreatePullRequestPublisherTest.java
@@ -1,0 +1,94 @@
+package com.gitee.jenkins.publisher;
+
+import static com.gitee.jenkins.publisher.TestUtility.GITEE_CONNECTION_V5;
+import static com.gitee.jenkins.publisher.TestUtility.OWNER_PATH;
+import static com.gitee.jenkins.publisher.TestUtility.REPO_PATH;
+import static com.gitee.jenkins.publisher.TestUtility.setupGiteeConnections;
+import static com.gitee.jenkins.publisher.TestUtility.verifyMatrixAggregatable;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static com.gitee.jenkins.publisher.TestUtility.mockSimpleBuild;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.model.HttpRequest;
+
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.StreamBuildListener;
+
+@WithJenkins
+@ExtendWith(MockServerExtension.class)
+public class GiteeCreatePullRequestPublisherTest {
+    private static JenkinsRule jenkins;
+
+    private static MockServerClient mockServerClient;
+    private BuildListener listener;
+
+    @BeforeAll
+    static void setUp(JenkinsRule rule, MockServerClient client) throws Exception {
+        jenkins = rule;
+        mockServerClient = client;
+        setupGiteeConnections(jenkins, client);
+    }
+
+    @BeforeEach
+    void setUp() {
+        listener = new StreamBuildListener(jenkins.createTaskListener().getLogger(), Charset.defaultCharset());
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServerClient.reset();
+    }
+
+    @Test
+    void matrixAggregatable() throws Exception {
+        verifyMatrixAggregatable(GiteeMessagePublisher.class, listener);
+    }
+
+    @Test
+    void success() throws InterruptedException, IOException {
+        HttpRequest createPullRequestStatus = prepareCreatePullRequest("v5");
+        mockServerClient.when(createPullRequestStatus).respond(response().withStatusCode(200));
+
+        GiteeCreatePullRequestPublisher p = new GiteeCreatePullRequestPublisher();
+        p.setRepo(REPO_PATH);
+        p.setOwner(OWNER_PATH);
+        p.setBase("base");
+        p.setHead("head");
+        p.setTitle("title");
+
+        p.perform(mockSimpleBuild(GITEE_CONNECTION_V5, Result.SUCCESS), null, listener);
+        mockServerClient.verify(createPullRequestStatus);
+    }
+
+    @Test
+    void failed() throws InterruptedException, IOException {
+        GiteeCreatePullRequestPublisher p = new GiteeCreatePullRequestPublisher();
+        p.setRepo(REPO_PATH);
+        p.setOwner(OWNER_PATH);
+        p.setBase("base");
+        p.setHead("head");
+        p.setTitle("title");
+
+        p.perform(mockSimpleBuild(GITEE_CONNECTION_V5, Result.FAILURE), null, listener);
+        mockServerClient.verifyZeroInteractions();
+    }
+
+    private HttpRequest prepareCreatePullRequest(String apiLevel) {
+        return request()
+                .withPath(String.format("/gitee/api/%s/repos/%s/%s/pulls", apiLevel, OWNER_PATH, REPO_PATH))
+                .withMethod("POST")
+                .withHeader("PRIVATE-TOKEN", "secret");
+    }
+
+}

--- a/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
+++ b/src/test/java/com/gitee/jenkins/publisher/TestUtility.java
@@ -48,6 +48,7 @@ final class TestUtility {
     static final String GITEE_CONNECTION_V5 = "GiteeV5";
     static final String BUILD_URL = "/build/123";
     static final String REPO_PATH = "testPath";
+    static final String OWNER_PATH = "testUser";
     static final String PULL_COMMIT_SHA = "eKJ3wuqJT98Kc8TCcBK7oggLR1E9Bty7eqSHfSLT";
     static final int BUILD_NUMBER = 1;
     static final int PROJECT_ID = 3;


### PR DESCRIPTION
Added tests for `GiteeCreatePullRequestPublisher.java`. Small bug fix to create pull request only on build success.

### Testing done
Ran tests locally on ubuntu 24 machine.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
