### PR TITLE
Fixed json-provider depend to latest in BOM, added jakarta-xml-bind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5473.vb_9533d9e5d88</version>
+        <version>5622.vc9c3051619f5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -132,10 +132,14 @@
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jakarta-xml-bind-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <!-- Needs to match the jackson version from plugin BOM -->
-      <version>2.19.2</version>
+      <version>2.20.0</version>
     </dependency>
 
     <!-- util dependencies -->


### PR DESCRIPTION
Updated `jackson-jakarta-rs-json-provider` dependency to be latest supported by BOM. Added `jakarta-xml-bind-api` to `pom.xml` to resolve upper bounds dependency error with latest BOM version (added in release [5506.va_222b_131ec34](https://github.com/jenkinsci/bom/releases/tag/5506.va_222b_131ec34)) 

<!-- Please describe your pull request here. -->

### Testing done
Ran on Ubuntu 24 machine with tests, ran trigger when create pull request on Gitee.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
