### PR TITLE
[JENKINS-76310] Make secret token work with CSP enforced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.504</jenkins.baseline>
-    <jenkins.version>2.540</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <mockserver.version>5.15.0</mockserver.version>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>

--- a/src/main/java/com/gitee/jenkins/trigger/GiteePushTrigger.java
+++ b/src/main/java/com/gitee/jenkins/trigger/GiteePushTrigger.java
@@ -35,16 +35,13 @@ import net.karneim.pojobuilder.GeneratePojoBuilder;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.Ancestor;
-import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 import java.io.ObjectStreamException;
-import java.security.SecureRandom;
 
 import static com.gitee.jenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
 import static com.gitee.jenkins.trigger.handler.pull.PullRequestHookTriggerHandlerFactory.newPullRequestHookTriggerHandler;
@@ -61,9 +58,6 @@ import static com.gitee.jenkins.trigger.handler.push.PushHookTriggerHandlerFacto
  *
  */
 public class GiteePushTrigger extends Trigger<Job<?, ?>> {
-
-    private static final SecureRandom RANDOM = new SecureRandom();
-
     private boolean triggerOnPush = true;
     private boolean triggerOnCommitComment = false;
     private boolean triggerOnOpenPullRequest = true;
@@ -681,17 +675,6 @@ public class GiteePushTrigger extends Trigger<Job<?, ?>> {
         public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
             save();
             return super.configure(req, formData);
-        }
-
-        public void doGenerateSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse2 response) {
-            byte[] random = new byte[16];   // 16x8=128bit worth of randomness, since we use md5 digest as the API token
-            RANDOM.nextBytes(random);
-            String secretToken = Util.toHexString(random);
-            response.setHeader("X-Jenkins-ValidateButton-Callback", "{\"callback\":\"updateSecretToken\",\"arguments\":[\"" + secretToken + "\"]}");
-        }
-
-        public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse2 response) {
-            response.setHeader("X-Jenkins-ValidateButton-Callback", "{\"callback\":\"updateSecretToken\",\"arguments\":[\"\"]}");
         }
     }
 }

--- a/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/adjunct.js
+++ b/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/adjunct.js
@@ -1,3 +1,13 @@
-function updateSecretToken(newValue) {
-    document.getElementById('giteeSecretToken').value = newValue;
-}
+Behaviour.specify("BUTTON.gitee-generate", "gitee-generate", 0, function (e) {
+    e.onclick = function (evt) {
+        document.getElementById('giteeSecretToken').value = [...Array(32)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+        evt.preventDefault();
+    };
+});
+
+Behaviour.specify("BUTTON.gitee-clear", "gitee-clear", 0, function (e) {
+    e.onclick = function (evt) {
+        document.getElementById('giteeSecretToken').value = "";
+        evt.preventDefault();
+    };
+});

--- a/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.jelly
+++ b/src/main/resources/com/gitee/jenkins/trigger/GiteePushTrigger/config.jelly
@@ -121,10 +121,8 @@
   </f:entry>
   <f:entry title="${%Secret.Token}" help="/plugin/gitee/help/help-secretToken.html">
     <st:adjunct includes="com.gitee.jenkins.trigger.GiteePushTrigger.adjunct"/>
-    <table>
-      <f:readOnlyTextbox field="secretToken" id="giteeSecretToken"/>
-      <f:validateButton title="${%Generate}" method="generateSecretToken"/>
-      <f:validateButton title="${%Clear}" method="clearSecretToken"/>
-    </table>
+    <f:readOnlyTextbox field="secretToken" id="giteeSecretToken"/>
+    <button class="jenkins-button gitee-generate jenkins-!-margin-right-1 jenkins-!-margin-top-1">${%Generate}</button>
+    <button class="jenkins-button gitee-clear jenkins-!-margin-top-1">${%Clear}</button>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-76310

Second iteration: No longer uses weird `f:validateButton` feature. I recommend squash-merging due to unclean history.

### Testing done

Manually navigated to the buttons and clicked them, checked CSP findings -- none. Work when CSP is enforced.

### Screenshots

I used this opportunity to make the buttons look nicer, now that we're not using `f:validateButton` anymore.

#### Before

<img width="915" height="328" alt="Screenshot 2025-12-02 at 18 08 56" src="https://github.com/user-attachments/assets/cb5860a7-ac74-4deb-b847-7f12ea383e90" />

#### After

<img width="927" height="218" alt="Screenshot 2025-12-02 at 18 07 51" src="https://github.com/user-attachments/assets/eea225d4-e2ff-43cf-94c2-c1e5b861f3dd" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
