### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <hpi.bundledArtifacts>angus-mail,apache-mime4j-core,apache-mime4j-dom,apache-mime4j-storage,asyncutil,codemodel,commons-codec,commons-io,istack-commons-runtime,istack-commons-tools,jackson-jakarta-rs-base,jackson-jakarta-rs-json-provider,jakarta.annotation-api,jakarta.mail-api,jakarta.validation-api,jakarta.ws.rs-api,jandex,jaxb-core,jaxb-jxc,jaxb-runtime,jaxb-xjc,jboss-logging,reactive-streams,relaxng-datatype,resteasy-client,resteasy-client-api,resteasy-core,resteasy-core-spi,resteasy-jaxb-provider,resteasy-multipart-provider,resteasy-tracing-api,rngom,txw2,xsom</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <mockserver.version>7.5.0</mockserver.version>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
@@ -75,6 +76,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>

--- a/src/main/java/com/gitee/jenkins/cause/CauseData.java
+++ b/src/main/java/com/gitee/jenkins/cause/CauseData.java
@@ -5,10 +5,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.markup.EscapedMarkupFormatter;
 import jenkins.model.Jenkins;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.*;
 

--- a/src/main/java/com/gitee/jenkins/connection/GiteeConnectionProperty.java
+++ b/src/main/java/com/gitee/jenkins/connection/GiteeConnectionProperty.java
@@ -12,7 +12,7 @@ import hudson.model.Run;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest2;

--- a/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClientBuilder.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/impl/ResteasyGiteeClientBuilder.java
@@ -18,7 +18,7 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Branch.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Branch.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Commit.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Commit.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Label.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Label.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Namespace.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Namespace.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Note.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Note.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Project.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Project.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/PullRequest.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/PullRequest.java
@@ -3,9 +3,9 @@ package com.gitee.jenkins.gitee.api.model;
 import com.gitee.jenkins.gitee.hook.model.PullRequestObjectAttributes;
 import com.gitee.jenkins.gitee.hook.model.State;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/Release.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/Release.java
@@ -1,8 +1,8 @@
 package com.gitee.jenkins.gitee.api.model;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/User.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/User.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.api.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/api/model/WebHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/api/model/WebHook.java
@@ -1,8 +1,8 @@
 package com.gitee.jenkins.gitee.api.model;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/BranchData.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/BranchData.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Yashin

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/Commit.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/Commit.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteHook.java
@@ -2,9 +2,9 @@ package com.gitee.jenkins.gitee.hook.model;
 
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Nikolay Ustinov

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteObjectAttributes.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/NoteObjectAttributes.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PipelineEventObjectAttributes.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PipelineEventObjectAttributes.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PipelineHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PipelineHook.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/Project.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/Project.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestHook.java
@@ -2,9 +2,9 @@ package com.gitee.jenkins.gitee.hook.model;
 
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestLabel.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestLabel.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestObjectAttributes.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PullRequestObjectAttributes.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/PushHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/PushHook.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/Repository.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/Repository.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/User.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/User.java
@@ -1,9 +1,9 @@
 package com.gitee.jenkins.gitee.hook.model;
 
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/gitee/hook/model/WebHook.java
+++ b/src/main/java/com/gitee/jenkins/gitee/hook/model/WebHook.java
@@ -1,8 +1,8 @@
 package com.gitee.jenkins.gitee.hook.model;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/trigger/filter/PullRequestLabelRegexFilter.java
+++ b/src/main/java/com/gitee/jenkins/trigger/filter/PullRequestLabelRegexFilter.java
@@ -2,7 +2,7 @@ package com.gitee.jenkins.trigger.filter;
 
 import java.util.Collection;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class PullRequestLabelRegexFilter implements PullRequestLabelFilter {
     private final String regex;

--- a/src/main/java/com/gitee/jenkins/trigger/filter/RegexBasedFilter.java
+++ b/src/main/java/com/gitee/jenkins/trigger/filter/RegexBasedFilter.java
@@ -1,6 +1,6 @@
 package com.gitee.jenkins.trigger.filter;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/gitee/jenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -14,7 +14,7 @@ import com.gitee.jenkins.trigger.handler.AbstractWebHookTriggerHandler;
 import hudson.model.*;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/pull/PullRequestHookTriggerHandlerImpl.java
@@ -16,7 +16,7 @@ import com.gitee.jenkins.util.BuildUtil;
 import hudson.model.*;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/gitee/jenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
+++ b/src/main/java/com/gitee/jenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
@@ -17,7 +17,7 @@ import com.gitee.jenkins.util.BuildUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import static com.gitee.jenkins.cause.CauseDataBuilder.causeData;
 import static com.gitee.jenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
 

--- a/src/main/java/com/gitee/jenkins/webhook/build/BuildWebHookAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/BuildWebHookAction.java
@@ -10,7 +10,7 @@ import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.gitee.jenkins.trigger.GiteePushTrigger;
 import com.gitee.jenkins.connection.GiteeConnectionConfig;

--- a/src/main/java/com/gitee/jenkins/webhook/build/LegacyBuildWebHookAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/LegacyBuildWebHookAction.java
@@ -10,7 +10,7 @@ import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.gitee.jenkins.trigger.GiteePushTrigger;
 import com.gitee.jenkins.connection.GiteeConnectionConfig;

--- a/src/main/java/com/gitee/jenkins/webhook/build/LegacyPipelineBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/LegacyPipelineBuildAction.java
@@ -9,7 +9,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.core.Authentication;
 
 import java.net.MalformedURLException;

--- a/src/main/java/com/gitee/jenkins/webhook/build/LegacyPushBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/LegacyPushBuildAction.java
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 import org.springframework.security.core.Authentication;
 

--- a/src/main/java/com/gitee/jenkins/webhook/build/PipelineBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/PipelineBuildAction.java
@@ -9,7 +9,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.core.Authentication;
 
 import java.net.MalformedURLException;

--- a/src/main/java/com/gitee/jenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/gitee/jenkins/webhook/build/PushBuildAction.java
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 import org.springframework.security.core.Authentication;
 

--- a/src/main/java/com/gitee/jenkins/workflow/AcceptGiteePullRequestStep.java
+++ b/src/main/java/com/gitee/jenkins/workflow/AcceptGiteePullRequestStep.java
@@ -11,7 +11,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
 
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/com/gitee/jenkins/workflow/AddGiteePullRequestCommentStep.java
+++ b/src/main/java/com/gitee/jenkins/workflow/AddGiteePullRequestCommentStep.java
@@ -12,7 +12,7 @@ import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
 
 import com.gitee.jenkins.gitee.api.model.PullRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;

--- a/src/test/java/com/gitee/jenkins/trigger/filter/AllBranchesFilterTest.java
+++ b/src/test/java/com/gitee/jenkins/trigger/filter/AllBranchesFilterTest.java
@@ -3,7 +3,7 @@ package com.gitee.jenkins.trigger.filter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed
- Moved all Commons Lang 2 usage to `org.apache.commons.lang3` across 41 files — `EqualsBuilder`,
  `HashCodeBuilder` and `ToStringBuilder` (25 classes each), plus `StringUtils` and
  `RandomStringUtils`. This is a package rename only; no call signatures change.
- Added the `commons-lang3-api` library plugin (versionless — the version comes from the Jenkins
  plugin BOM).
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

At ~90 call sites a hand rewrite to `java.util.Objects` would have been unreviewable, so this takes
the package-rename route.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
